### PR TITLE
Spring Cloud多注册实现

### DIFF
--- a/microsphere-spring-cloud-commons/pom.xml
+++ b/microsphere-spring-cloud-commons/pom.xml
@@ -119,6 +119,27 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- Spring Cloud Nacos -->
+        <dependency>
+            <groupId>com.alibaba.cloud</groupId>
+            <artifactId>spring-cloud-starter-alibaba-nacos-discovery</artifactId>
+<!--            <scope>test</scope>-->
+        </dependency>
+
     </dependencies>
+
+    <repositories>
+        <repository>
+            <id>ossrh</id>
+            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+            <name>nexus</name>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
 
 </project>

--- a/microsphere-spring-cloud-commons/pom.xml
+++ b/microsphere-spring-cloud-commons/pom.xml
@@ -123,23 +123,9 @@
         <dependency>
             <groupId>com.alibaba.cloud</groupId>
             <artifactId>spring-cloud-starter-alibaba-nacos-discovery</artifactId>
-<!--            <scope>test</scope>-->
+            <scope>test</scope>
         </dependency>
 
     </dependencies>
-
-    <repositories>
-        <repository>
-            <id>ossrh</id>
-            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
-            <name>nexus</name>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
 
 </project>

--- a/microsphere-spring-cloud-commons/src/main/java/io/microsphere/spring/cloud/client/service/registry/MultipleAutoServiceRegistration.java
+++ b/microsphere-spring-cloud-commons/src/main/java/io/microsphere/spring/cloud/client/service/registry/MultipleAutoServiceRegistration.java
@@ -1,0 +1,8 @@
+package io.microsphere.spring.cloud.client.service.registry;
+
+/**
+ * @author <a href="mailto:maimengzzz@gmail.com">韩超</a>
+ * @since 1.0
+ */
+public class MultipleAutoServiceRegistration {
+}

--- a/microsphere-spring-cloud-commons/src/main/java/io/microsphere/spring/cloud/client/service/registry/MultipleAutoServiceRegistration.java
+++ b/microsphere-spring-cloud-commons/src/main/java/io/microsphere/spring/cloud/client/service/registry/MultipleAutoServiceRegistration.java
@@ -1,8 +1,41 @@
 package io.microsphere.spring.cloud.client.service.registry;
 
+import org.springframework.cloud.client.serviceregistry.AbstractAutoServiceRegistration;
+import org.springframework.cloud.client.serviceregistry.AutoServiceRegistrationProperties;
+import org.springframework.cloud.client.serviceregistry.ServiceRegistry;
+
 /**
  * @author <a href="mailto:maimengzzz@gmail.com">韩超</a>
- * @since 1.0
+ * @since 1.0.0
  */
-public class MultipleAutoServiceRegistration {
+public class MultipleAutoServiceRegistration extends AbstractAutoServiceRegistration<MultipleRegistration> {
+
+    private final AutoServiceRegistrationProperties autoServiceRegistrationProperties;
+    private final MultipleRegistration multipleRegistration;
+
+    public MultipleAutoServiceRegistration(MultipleRegistration multipleRegistration, ServiceRegistry<MultipleRegistration> serviceRegistry, AutoServiceRegistrationProperties properties) {
+        super(serviceRegistry, properties);
+        this.autoServiceRegistrationProperties = properties;
+        this.multipleRegistration = multipleRegistration;
+    }
+
+    @Override
+    protected Object getConfiguration() {
+        return null;
+    }
+
+    @Override
+    protected boolean isEnabled() {
+        return this.autoServiceRegistrationProperties.isEnabled();
+    }
+
+    @Override
+    protected MultipleRegistration getRegistration() {
+        return this.multipleRegistration;
+    }
+
+    @Override
+    protected MultipleRegistration getManagementRegistration() {
+        return this.multipleRegistration;
+    }
 }

--- a/microsphere-spring-cloud-commons/src/main/java/io/microsphere/spring/cloud/client/service/registry/MultipleRegistration.java
+++ b/microsphere-spring-cloud-commons/src/main/java/io/microsphere/spring/cloud/client/service/registry/MultipleRegistration.java
@@ -1,0 +1,88 @@
+package io.microsphere.spring.cloud.client.service.registry;
+
+import org.springframework.cloud.client.serviceregistry.Registration;
+import org.springframework.util.CollectionUtils;
+
+import java.net.URI;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * @author <a href="mailto:maimengzzz@gmail.com">韩超</a>
+ * @since 1.0
+ */
+public class MultipleRegistration implements Registration {
+
+    private Map<Class<? extends Registration>, Registration> registrationMap = new HashMap<>();
+    private Registration defaultRegistration;
+
+    public MultipleRegistration(Class<? extends Registration> defaultRegistrationClass, Collection<Registration> registrations) {
+        if (CollectionUtils.isEmpty(registrations))
+            throw new IllegalArgumentException("registrations cannot be empty");
+        //init map
+        for (Registration registration : registrations) {
+            Class<? extends Registration> clazz = registration.getClass();
+            if (clazz.equals(defaultRegistrationClass))
+                this.defaultRegistration = registration;
+            this.registrationMap.put(clazz, registration);
+        }
+
+        if (defaultRegistration == null)
+            throw new IllegalArgumentException("default registration not specified");
+    }
+
+    @Override
+    public String getServiceId() {
+        return getDefaultRegistration().getServiceId();
+    }
+
+    @Override
+    public String getHost() {
+        return getDefaultRegistration().getHost();
+    }
+
+    @Override
+    public int getPort() {
+        return getDefaultRegistration().getPort();
+    }
+
+    @Override
+    public boolean isSecure() {
+        return getDefaultRegistration().isSecure();
+    }
+
+    @Override
+    public URI getUri() {
+        return getDefaultRegistration().getUri();
+    }
+
+    @Override
+    public Map<String, String> getMetadata() {
+        //组合metadata
+
+        Map<String, String> metaData = new HashMap<>();
+
+        for (Registration registration : this.registrationMap.values()) {
+            Map<String, String> map = registration.getMetadata();
+            //todo 不同实现考虑不同前缀?
+            if (!CollectionUtils.isEmpty(map))
+                metaData.putAll(map);
+        }
+
+        return metaData;
+    }
+
+    public Registration getDefaultRegistration() {
+        return defaultRegistration;
+    }
+
+    public Optional<Registration> special(Class<? extends Registration> specialClass) {
+        if (specialClass.equals(Registration.class))
+            return Optional.of(this);
+
+
+        return Optional.ofNullable(this.registrationMap.get(specialClass));
+    }
+}

--- a/microsphere-spring-cloud-commons/src/main/java/io/microsphere/spring/cloud/client/service/registry/MultipleServiceRegistry.java
+++ b/microsphere-spring-cloud-commons/src/main/java/io/microsphere/spring/cloud/client/service/registry/MultipleServiceRegistry.java
@@ -1,0 +1,83 @@
+package io.microsphere.spring.cloud.client.service.registry;
+
+import org.springframework.cloud.client.serviceregistry.Registration;
+import org.springframework.cloud.client.serviceregistry.ServiceRegistry;
+import org.springframework.core.ResolvableType;
+import org.springframework.util.CollectionUtils;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * @author <a href="mailto:maimengzzz@gmail.com">韩超</a>
+ * @since 1.0
+ */
+public class MultipleServiceRegistry implements ServiceRegistry<MultipleRegistration> {
+
+    private final Collection<ServiceRegistry> serviceRegistries;
+
+    private ServiceRegistry defaultServiceRegistry;
+
+    private final Map<Class<? extends Registration>, ServiceRegistry> registryMap = new HashMap<>();
+
+    public MultipleServiceRegistry(Class<? extends ServiceRegistry> defaultServiceRegistryClass, Collection<ServiceRegistry> serviceRegistries) {
+        if (CollectionUtils.isEmpty(serviceRegistries))
+            throw new IllegalArgumentException("service registry cannot be empty");
+
+        this.serviceRegistries = serviceRegistries;
+
+        for (ServiceRegistry<? extends Registration> serviceRegistry : serviceRegistries) {
+            Class<? extends Registration> registrationClass = getRegistrationClass(serviceRegistry.getClass());
+            this.registryMap.put(registrationClass, serviceRegistry);
+            if (defaultServiceRegistryClass.equals(serviceRegistry.getClass()))
+                defaultServiceRegistry = serviceRegistry;
+        }
+
+        if (defaultServiceRegistry == null)
+            throw new IllegalArgumentException("default service registry not specified");
+
+    }
+
+    @Override
+    public void register(MultipleRegistration registration) {
+        this.registryMap.forEach((clazz, serviceRegistry) -> {
+            Optional<Registration> selectedRegistration = registration.special(clazz);
+            selectedRegistration.ifPresent(serviceRegistry::register);
+        });
+    }
+
+    @Override
+    public void deregister(MultipleRegistration registration) {
+        this.registryMap.forEach((clazz, serviceRegistry) -> {
+            Optional<Registration> selectedRegistration = registration.special(clazz);
+            selectedRegistration.ifPresent(serviceRegistry::deregister);
+        });
+    }
+
+    @Override
+    public void close() {
+        for (ServiceRegistry serviceRegistry : this.serviceRegistries)
+            serviceRegistry.close();
+    }
+
+    @Override
+    public void setStatus(MultipleRegistration registration, String status) {
+        this.registryMap.forEach((clazz, serviceRegistry) -> {
+            Optional<Registration> selectedRegistration = registration.special(clazz);
+            if (selectedRegistration.isPresent())
+                serviceRegistry.setStatus(registration, status);
+        });
+    }
+
+    @Override
+    public <T> T getStatus(MultipleRegistration registration) {
+        return (T) defaultServiceRegistry.getStatus(registration.getDefaultRegistration());
+    }
+
+    private static Class<? extends Registration> getRegistrationClass(Class<? extends ServiceRegistry> serviceRegistryClass) {
+        ResolvableType resolvableType = ResolvableType.forClass(serviceRegistryClass);
+        return (Class<? extends Registration>)resolvableType.getInterfaces()[0].getGeneric(0).getRawClass();
+    }
+}

--- a/microsphere-spring-cloud-commons/src/main/java/io/microsphere/spring/cloud/client/service/registry/RegistrationMetaData.java
+++ b/microsphere-spring-cloud-commons/src/main/java/io/microsphere/spring/cloud/client/service/registry/RegistrationMetaData.java
@@ -1,0 +1,119 @@
+package io.microsphere.spring.cloud.client.service.registry;
+
+import org.springframework.cloud.client.serviceregistry.Registration;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.ObjectUtils;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * @author <a href="mailto:maimengzzz@gmail.com">韩超</a>
+ * @since 1.0.0
+ */
+public final class RegistrationMetaData implements Map<String, String> {
+
+    /**
+     * MetaData information manually added by the application,usually specified by configuration
+     */
+    private final Map<String, String> applicationMetaData;
+    private final Collection<Registration> registrations;
+    private final Object lock = new Object();
+
+    public RegistrationMetaData(Collection<Registration> registrations) {
+        if (CollectionUtils.isEmpty(registrations))
+            throw new IllegalArgumentException("registrations cannot be empty");
+
+        this.registrations = registrations;
+        this.applicationMetaData = new ConcurrentHashMap<>();
+        for (Registration registration : registrations) {
+            Map<String, String> metaData = registration.getMetadata();
+            if (!CollectionUtils.isEmpty(metaData)) {
+                //check key and value must not be null
+                metaData.forEach((k, v) -> {
+                    if (ObjectUtils.isEmpty(k) || ObjectUtils.isEmpty(v))
+                        return;
+                    this.applicationMetaData.put(k, v);
+                });
+            }
+        }
+    }
+
+    @Override
+    public int size() {
+        return applicationMetaData.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return this.applicationMetaData.isEmpty();
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+        return this.applicationMetaData.containsKey(key);
+    }
+
+    @Override
+    public boolean containsValue(Object value) {
+        return this.applicationMetaData.containsValue(value);
+    }
+
+    @Override
+    public String get(Object key) {
+        return this.applicationMetaData.get(key);
+    }
+
+    @Override
+    public String put(String key, String value) {
+        synchronized (lock) {
+            this.registrations.forEach(registration -> {
+                registration.getMetadata().put(key, value);
+            });
+        }
+        return this.applicationMetaData.put(key, value);
+    }
+
+    @Override
+    public String remove(Object key) {
+        synchronized (lock) {
+            this.registrations.forEach(registration -> {
+                registration.getMetadata().remove(key);
+            });
+        }
+        return this.applicationMetaData.remove(key);
+    }
+
+    @Override
+    public void putAll(Map<? extends String, ? extends String> m) {
+        synchronized (lock) {
+            this.registrations.forEach(registration -> {
+                registration.getMetadata().putAll(m);
+            });
+        }
+        this.applicationMetaData.putAll(m);
+    }
+
+    @Override
+    public void clear() {
+        synchronized (lock) {
+            this.registrations.forEach(registration -> registration.getMetadata().clear());
+        }
+        this.applicationMetaData.clear();
+    }
+
+    @Override
+    public Set<String> keySet() {
+        return Collections.unmodifiableSet(this.applicationMetaData.keySet());
+    }
+
+    @Override
+    public Collection<String> values() {
+        return Collections.unmodifiableCollection(this.applicationMetaData.values());
+    }
+
+    @Override
+    public Set<Entry<String, String>> entrySet() {
+        return this.applicationMetaData.entrySet();
+    }
+}

--- a/microsphere-spring-cloud-commons/src/main/java/io/microsphere/spring/cloud/client/service/registry/aspect/EventPublishingRegistrationAspect.java
+++ b/microsphere-spring-cloud-commons/src/main/java/io/microsphere/spring/cloud/client/service/registry/aspect/EventPublishingRegistrationAspect.java
@@ -16,6 +16,7 @@
  */
 package io.microsphere.spring.cloud.client.service.registry.aspect;
 
+import io.microsphere.spring.cloud.client.service.registry.MultipleServiceRegistry;
 import io.microsphere.spring.cloud.client.service.registry.RegistrationCustomizer;
 import io.microsphere.spring.cloud.client.service.registry.event.RegistrationDeregisteredEvent;
 import io.microsphere.spring.cloud.client.service.registry.event.RegistrationPreDeregisteredEvent;
@@ -40,7 +41,9 @@ import org.springframework.context.ApplicationContextAware;
  * @see RegistrationPreDeregisteredEvent
  * @see RegistrationDeregisteredEvent
  * @since 1.0.0
+ * @deprecated using {@link MultipleServiceRegistry}
  */
+@Deprecated
 @Aspect
 public class EventPublishingRegistrationAspect implements ApplicationContextAware {
 

--- a/microsphere-spring-cloud-commons/src/main/java/io/microsphere/spring/cloud/client/service/registry/autoconfigure/ServiceRegistryAutoConfiguration.java
+++ b/microsphere-spring-cloud-commons/src/main/java/io/microsphere/spring/cloud/client/service/registry/autoconfigure/ServiceRegistryAutoConfiguration.java
@@ -16,13 +16,17 @@
  */
 package io.microsphere.spring.cloud.client.service.registry.autoconfigure;
 
-import com.alibaba.cloud.nacos.registry.NacosRegistration;
-import com.alibaba.cloud.nacos.registry.NacosServiceRegistry;
+import io.microsphere.spring.cloud.client.service.registry.MultipleAutoServiceRegistration;
 import io.microsphere.spring.cloud.client.service.registry.MultipleRegistration;
 import io.microsphere.spring.cloud.client.service.registry.MultipleServiceRegistry;
+import io.microsphere.spring.cloud.client.service.registry.RegistrationCustomizer;
 import io.microsphere.spring.cloud.client.service.registry.aspect.EventPublishingRegistrationAspect;
 import io.microsphere.spring.cloud.client.service.registry.condition.ConditionalOnAutoServiceRegistrationEnabled;
 import io.microsphere.spring.cloud.client.service.registry.condition.ConditionalOnMultipleRegistrationEnabled;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.cloud.client.serviceregistry.AutoServiceRegistrationProperties;
 import org.springframework.cloud.client.serviceregistry.Registration;
 import org.springframework.cloud.client.serviceregistry.ServiceRegistry;
 import org.springframework.context.annotation.Bean;
@@ -30,7 +34,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Primary;
 
-import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Auto-Configuration class for {@link ServiceRegistry ServiceRegistry}
@@ -48,15 +52,28 @@ public class ServiceRegistryAutoConfiguration {
     @ConditionalOnMultipleRegistrationEnabled
     @Primary
     @Bean
-    public MultipleRegistration multipleRegistration(List<Registration> registrationProvider) {
-        return new MultipleRegistration(NacosRegistration.class, registrationProvider);
+    public MultipleRegistration multipleRegistration(@Value("${microsphere.spring.cloud.default-registration.type}") Class<? extends Registration> defaultRegistrationClass,
+                                                     ObjectProvider<Registration> registrationProvider) {
+        return new MultipleRegistration(defaultRegistrationClass, registrationProvider.stream().collect(Collectors.toList()));
     }
 
     @ConditionalOnMultipleRegistrationEnabled
     @Primary
     @Bean
-    public MultipleServiceRegistry multipleServiceRegistry(List<ServiceRegistry> serviceRegistries) {
-        return new MultipleServiceRegistry(NacosServiceRegistry.class, serviceRegistries);
+    public MultipleServiceRegistry multipleServiceRegistry(@Value("${microsphere.spring.cloud.default-service-registry.type}") Class<? extends ServiceRegistry> defaultServiceRegistryClass,
+                                                           ObjectProvider<ServiceRegistry> serviceRegistries,
+                                                           ObjectProvider<RegistrationCustomizer> registrationCustomizers)  {
+        return new MultipleServiceRegistry(defaultServiceRegistryClass, serviceRegistries.stream().collect(Collectors.toList()), registrationCustomizers);
     }
 
+    @ConditionalOnMultipleRegistrationEnabled
+    @ConditionalOnBean(AutoServiceRegistrationProperties.class)
+    @Primary
+    @Bean
+    public MultipleAutoServiceRegistration multipleAutoServiceRegistration(
+            MultipleRegistration multipleRegistration,
+            MultipleServiceRegistry serviceRegistry,
+            AutoServiceRegistrationProperties properties) {
+        return new MultipleAutoServiceRegistration(multipleRegistration, serviceRegistry, properties);
+    }
 }

--- a/microsphere-spring-cloud-commons/src/main/java/io/microsphere/spring/cloud/client/service/registry/autoconfigure/ServiceRegistryAutoConfiguration.java
+++ b/microsphere-spring-cloud-commons/src/main/java/io/microsphere/spring/cloud/client/service/registry/autoconfigure/ServiceRegistryAutoConfiguration.java
@@ -16,11 +16,21 @@
  */
 package io.microsphere.spring.cloud.client.service.registry.autoconfigure;
 
+import com.alibaba.cloud.nacos.registry.NacosRegistration;
+import com.alibaba.cloud.nacos.registry.NacosServiceRegistry;
+import io.microsphere.spring.cloud.client.service.registry.MultipleRegistration;
+import io.microsphere.spring.cloud.client.service.registry.MultipleServiceRegistry;
 import io.microsphere.spring.cloud.client.service.registry.aspect.EventPublishingRegistrationAspect;
 import io.microsphere.spring.cloud.client.service.registry.condition.ConditionalOnAutoServiceRegistrationEnabled;
+import io.microsphere.spring.cloud.client.service.registry.condition.ConditionalOnMultipleRegistrationEnabled;
+import org.springframework.cloud.client.serviceregistry.Registration;
 import org.springframework.cloud.client.serviceregistry.ServiceRegistry;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+
+import java.util.List;
 
 /**
  * Auto-Configuration class for {@link ServiceRegistry ServiceRegistry}
@@ -34,4 +44,19 @@ import org.springframework.context.annotation.Import;
         EventPublishingRegistrationAspect.class
 })
 public class ServiceRegistryAutoConfiguration {
+
+    @ConditionalOnMultipleRegistrationEnabled
+    @Primary
+    @Bean
+    public MultipleRegistration multipleRegistration(List<Registration> registrationProvider) {
+        return new MultipleRegistration(NacosRegistration.class, registrationProvider);
+    }
+
+    @ConditionalOnMultipleRegistrationEnabled
+    @Primary
+    @Bean
+    public MultipleServiceRegistry multipleServiceRegistry(List<ServiceRegistry> serviceRegistries) {
+        return new MultipleServiceRegistry(NacosServiceRegistry.class, serviceRegistries);
+    }
+
 }

--- a/microsphere-spring-cloud-commons/src/main/java/io/microsphere/spring/cloud/client/service/registry/autoconfigure/WebMvcServiceRegistryAutoConfiguration.java
+++ b/microsphere-spring-cloud-commons/src/main/java/io/microsphere/spring/cloud/client/service/registry/autoconfigure/WebMvcServiceRegistryAutoConfiguration.java
@@ -25,6 +25,7 @@ import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.autoconfigure.web.servlet.DispatcherServletRegistrationBean;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
@@ -51,6 +52,7 @@ import static org.springframework.boot.autoconfigure.condition.ConditionalOnWebA
  * @since 1.0.0
  */
 @Configuration(proxyBeanMethods = false)
+@ConditionalOnBean(Registration.class)
 @ConditionalOnWebApplication(type = SERVLET)
 @ConditionalOnAutoServiceRegistrationEnabled
 @AutoConfigureAfter(value = {
@@ -63,7 +65,7 @@ public class WebMvcServiceRegistryAutoConfiguration {
     private static final String[] DEFAULT_URL_MAPPINGS = {"/*"};
 
     @Autowired
-    private ObjectProvider<Registration> registrationProvider;
+    private Registration registration;
 
     @Value("${management.endpoints.web.base-path:/actuator}")
     private String actuatorBasePath;
@@ -78,10 +80,8 @@ public class WebMvcServiceRegistryAutoConfiguration {
 
     @EventListener(WebEndpointMappingsReadyEvent.class)
     public void onApplicationEvent(WebEndpointMappingsReadyEvent event) {
-        registrationProvider.ifAvailable(registration -> {
-            Collection<WebEndpointMapping> webEndpointMappings = event.getMappings();
-            attachWebMappingsMetadata(registration, webEndpointMappings);
-        });
+        Collection<WebEndpointMapping> webEndpointMappings = event.getMappings();
+        attachWebMappingsMetadata(registration, webEndpointMappings);
     }
 
     private void attachWebMappingsMetadata(Registration registration, Collection<WebEndpointMapping> webEndpointMappings) {

--- a/microsphere-spring-cloud-commons/src/main/java/io/microsphere/spring/cloud/client/service/registry/condition/ConditionalOnMultipleRegistrationEnabled.java
+++ b/microsphere-spring-cloud-commons/src/main/java/io/microsphere/spring/cloud/client/service/registry/condition/ConditionalOnMultipleRegistrationEnabled.java
@@ -5,7 +5,8 @@ import org.springframework.core.annotation.AliasFor;
 
 import java.lang.annotation.*;
 
-import static io.microsphere.spring.cloud.commons.constants.CommonsPropertyConstants.MULTIPLE_REGISTRATION_ENABLED_PROPERTY_NAME;
+import static io.microsphere.spring.cloud.commons.constants.CommonsPropertyConstants.*;
+
 /**
  * @author <a href="mailto:maimengzzz@gmail.com">韩超</a>
  * @since 1.0
@@ -13,25 +14,10 @@ import static io.microsphere.spring.cloud.commons.constants.CommonsPropertyConst
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE, ElementType.METHOD})
 @Documented
-@ConditionalOnProperty(name = MULTIPLE_REGISTRATION_ENABLED_PROPERTY_NAME)
+@ConditionalOnProperty(name = {MULTIPLE_REGISTRATION_ENABLED_PROPERTY_NAME,
+        MULTIPLE_REGISTRATION_DEFAULT_REGISTRATION_PROPERTY_NAME,
+        MULTIPLE_REGISTRATION_DEFAULT_REGISTRY_PROPERTY_NAME
+})
 public @interface ConditionalOnMultipleRegistrationEnabled {
 
-
-    /**
-     * The string representation of the expected value for the properties. If not
-     * specified, the property must <strong>not</strong> be equal to {@code false}.
-     *
-     * @return the expected value
-     */
-    @AliasFor(annotation = ConditionalOnProperty.class, attribute = "havingValue")
-    String havingValue() default "";
-
-    /**
-     * Specify if the condition should match if the property is not set. Defaults to
-     * {@code true}.
-     *
-     * @return if the condition should match if the property is missing
-     */
-    @AliasFor(annotation = ConditionalOnProperty.class, attribute = "matchIfMissing")
-    boolean matchIfMissing() default true;
 }

--- a/microsphere-spring-cloud-commons/src/main/java/io/microsphere/spring/cloud/client/service/registry/condition/ConditionalOnMultipleRegistrationEnabled.java
+++ b/microsphere-spring-cloud-commons/src/main/java/io/microsphere/spring/cloud/client/service/registry/condition/ConditionalOnMultipleRegistrationEnabled.java
@@ -1,0 +1,37 @@
+package io.microsphere.spring.cloud.client.service.registry.condition;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.core.annotation.AliasFor;
+
+import java.lang.annotation.*;
+
+import static io.microsphere.spring.cloud.commons.constants.CommonsPropertyConstants.MULTIPLE_REGISTRATION_ENABLED_PROPERTY_NAME;
+/**
+ * @author <a href="mailto:maimengzzz@gmail.com">韩超</a>
+ * @since 1.0
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Documented
+@ConditionalOnProperty(name = MULTIPLE_REGISTRATION_ENABLED_PROPERTY_NAME)
+public @interface ConditionalOnMultipleRegistrationEnabled {
+
+
+    /**
+     * The string representation of the expected value for the properties. If not
+     * specified, the property must <strong>not</strong> be equal to {@code false}.
+     *
+     * @return the expected value
+     */
+    @AliasFor(annotation = ConditionalOnProperty.class, attribute = "havingValue")
+    String havingValue() default "";
+
+    /**
+     * Specify if the condition should match if the property is not set. Defaults to
+     * {@code true}.
+     *
+     * @return if the condition should match if the property is missing
+     */
+    @AliasFor(annotation = ConditionalOnProperty.class, attribute = "matchIfMissing")
+    boolean matchIfMissing() default true;
+}

--- a/microsphere-spring-cloud-commons/src/main/java/io/microsphere/spring/cloud/commons/constants/CommonsPropertyConstants.java
+++ b/microsphere-spring-cloud-commons/src/main/java/io/microsphere/spring/cloud/commons/constants/CommonsPropertyConstants.java
@@ -52,4 +52,9 @@ public interface CommonsPropertyConstants {
      */
     String MICROSPHERE_SPRING_CLOUD_WEB_MVC_PROPERTY_NAME_PREFIX = MICROSPHERE_SPRING_CLOUD_PROPERTY_NAME_PREFIX + "web.mvc.";
 
+    /**
+     * The property name for Spring Cloud Service Registry Auto-Registration Feature
+     */
+    String MULTIPLE_REGISTRATION_ENABLED_PROPERTY_NAME = MICROSPHERE_SPRING_CLOUD_PROPERTY_NAME_PREFIX + "multiple-registration." + ENABLED_PROPERTY_NAME;
+
 }

--- a/microsphere-spring-cloud-commons/src/main/java/io/microsphere/spring/cloud/commons/constants/CommonsPropertyConstants.java
+++ b/microsphere-spring-cloud-commons/src/main/java/io/microsphere/spring/cloud/commons/constants/CommonsPropertyConstants.java
@@ -53,8 +53,12 @@ public interface CommonsPropertyConstants {
     String MICROSPHERE_SPRING_CLOUD_WEB_MVC_PROPERTY_NAME_PREFIX = MICROSPHERE_SPRING_CLOUD_PROPERTY_NAME_PREFIX + "web.mvc.";
 
     /**
-     * The property name for Spring Cloud Service Registry Auto-Registration Feature
+     * The property name for Multiple Service Registry Enabled Feature
      */
     String MULTIPLE_REGISTRATION_ENABLED_PROPERTY_NAME = MICROSPHERE_SPRING_CLOUD_PROPERTY_NAME_PREFIX + "multiple-registration." + ENABLED_PROPERTY_NAME;
+
+    String MULTIPLE_REGISTRATION_DEFAULT_REGISTRATION_PROPERTY_NAME = MICROSPHERE_SPRING_CLOUD_PROPERTY_NAME_PREFIX + "default-registration.type";
+
+    String MULTIPLE_REGISTRATION_DEFAULT_REGISTRY_PROPERTY_NAME = MICROSPHERE_SPRING_CLOUD_PROPERTY_NAME_PREFIX + "default-service-registry.type";
 
 }

--- a/microsphere-spring-cloud-commons/src/test/java/io/microsphere/spring/cloud/client/service/registry/MultipleServiceRegistryTest.java
+++ b/microsphere-spring-cloud-commons/src/test/java/io/microsphere/spring/cloud/client/service/registry/MultipleServiceRegistryTest.java
@@ -4,39 +4,59 @@ import com.alibaba.cloud.nacos.NacosServiceAutoConfiguration;
 import com.alibaba.cloud.nacos.discovery.NacosDiscoveryAutoConfiguration;
 import com.alibaba.cloud.nacos.registry.NacosServiceRegistryAutoConfiguration;
 import com.alibaba.cloud.nacos.util.UtilIPv6AutoConfiguration;
+import com.netflix.appinfo.ApplicationInfoManager;
+import com.netflix.appinfo.InstanceInfo;
 import io.microsphere.spring.cloud.client.service.registry.autoconfigure.ServiceRegistryAutoConfiguration;
+import io.microsphere.spring.cloud.client.service.registry.event.RegistrationPreRegisteredEvent;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.cloud.client.serviceregistry.*;
+import org.springframework.cloud.client.CommonsClientAutoConfiguration;
+import org.springframework.cloud.client.serviceregistry.AutoServiceRegistrationAutoConfiguration;
+import org.springframework.cloud.client.serviceregistry.AutoServiceRegistrationProperties;
+import org.springframework.cloud.client.serviceregistry.Registration;
+import org.springframework.cloud.client.serviceregistry.ServiceRegistry;
 import org.springframework.cloud.commons.util.UtilAutoConfiguration;
+import org.springframework.cloud.netflix.eureka.EurekaClientAutoConfiguration;
+import org.springframework.cloud.netflix.eureka.config.DiscoveryClientOptionalArgsConfiguration;
+import org.springframework.cloud.netflix.eureka.serviceregistry.EurekaRegistration;
+import org.springframework.context.ApplicationListener;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = {
-        AutoServiceRegistrationConfiguration.class,
         AutoServiceRegistrationAutoConfiguration.class,
+        CommonsClientAutoConfiguration.class,
+        EurekaClientAutoConfiguration.class,
+        DiscoveryClientOptionalArgsConfiguration.class,
         NacosServiceRegistryAutoConfiguration.class,
         NacosServiceAutoConfiguration.class,
         NacosDiscoveryAutoConfiguration.class,
         UtilIPv6AutoConfiguration.class,
         UtilAutoConfiguration.class,
         MultipleServiceRegistryTest.class,
-        ServiceRegistryAutoConfiguration.class
+        ServiceRegistryAutoConfiguration.class,
 })
 @TestPropertySource(
         properties = {
                 "spring.application.name=test",
                 "microsphere.spring.cloud.multiple-registration.enabled=true",
+                "microsphere.spring.cloud.default-registration.type=com.alibaba.cloud.nacos.registry.NacosRegistration",
+                "microsphere.spring.cloud.default-service-registry.type=com.alibaba.cloud.nacos.registry.NacosServiceRegistry",
                 "spring.cloud.service-registry.auto-registration.enabled=true",
                 "spring.cloud.nacos.discovery.namespace=f7ad23e0-f581-4516-9420-8c50aa6a7b89",
+                "spring.cloud.nacos.discovery.metadata.key=value",
+                "eureka.client.service-url.defaultZone=http://127.0.0.1:12345/eureka",
         }
 )
-class MultipleServiceRegistryTest {
+class MultipleServiceRegistryTest implements ApplicationListener<RegistrationPreRegisteredEvent> {
 
 
     @Autowired
@@ -45,17 +65,44 @@ class MultipleServiceRegistryTest {
     private AutoServiceRegistrationProperties properties;
     @Autowired
     private Registration registration;
+    @Autowired
+    private MultipleAutoServiceRegistration autoServiceRegistration;
+
+    @Override
+    public void onApplicationEvent(RegistrationPreRegisteredEvent event) {
+        this.registration.getMetadata().put("my-key", "my-value");
+        if (event.getRegistration() instanceof EurekaRegistration) {
+            EurekaRegistration eurekaRegistration = (EurekaRegistration) event.getRegistration();
+
+
+            ApplicationInfoManager applicationInfoManager = eurekaRegistration.getApplicationInfoManager();
+            InstanceInfo instanceInfo = applicationInfoManager.getInfo();
+            Map<String, String> metadata = registration.getMetadata();
+            // Sync metadata from Registration to InstanceInfo
+            instanceInfo.getMetadata().putAll(metadata);
+        }
+    }
 
     @Test
-    public void test() {
+    public void test() throws Exception {
         assertNotNull(serviceRegistry);
         assertNotNull(registration);
+        autoServiceRegistration.start();
+        Thread.sleep(60 * 1000);
 
-        serviceRegistry.register(registration);
+        autoServiceRegistration.stop();
+    }
 
-        while (true) {
+    @Test
+    public void testMetaData() throws Exception {
+        assertNotNull(registration);
 
-        }
+        autoServiceRegistration.start();
+
+        assertEquals(registration.getMetadata().get("my-key"), "my-value");
+        Thread.sleep(60 * 1000);
+
+        autoServiceRegistration.stop();
     }
 
 

--- a/microsphere-spring-cloud-commons/src/test/java/io/microsphere/spring/cloud/client/service/registry/MultipleServiceRegistryTest.java
+++ b/microsphere-spring-cloud-commons/src/test/java/io/microsphere/spring/cloud/client/service/registry/MultipleServiceRegistryTest.java
@@ -1,0 +1,62 @@
+package io.microsphere.spring.cloud.client.service.registry;
+
+import com.alibaba.cloud.nacos.NacosServiceAutoConfiguration;
+import com.alibaba.cloud.nacos.discovery.NacosDiscoveryAutoConfiguration;
+import com.alibaba.cloud.nacos.registry.NacosServiceRegistryAutoConfiguration;
+import com.alibaba.cloud.nacos.util.UtilIPv6AutoConfiguration;
+import io.microsphere.spring.cloud.client.service.registry.autoconfigure.ServiceRegistryAutoConfiguration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cloud.client.serviceregistry.*;
+import org.springframework.cloud.commons.util.UtilAutoConfiguration;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {
+        AutoServiceRegistrationConfiguration.class,
+        AutoServiceRegistrationAutoConfiguration.class,
+        NacosServiceRegistryAutoConfiguration.class,
+        NacosServiceAutoConfiguration.class,
+        NacosDiscoveryAutoConfiguration.class,
+        UtilIPv6AutoConfiguration.class,
+        UtilAutoConfiguration.class,
+        MultipleServiceRegistryTest.class,
+        ServiceRegistryAutoConfiguration.class
+})
+@TestPropertySource(
+        properties = {
+                "spring.application.name=test",
+                "microsphere.spring.cloud.multiple-registration.enabled=true",
+                "spring.cloud.service-registry.auto-registration.enabled=true",
+                "spring.cloud.nacos.discovery.namespace=f7ad23e0-f581-4516-9420-8c50aa6a7b89",
+        }
+)
+class MultipleServiceRegistryTest {
+
+
+    @Autowired
+    private ServiceRegistry serviceRegistry;
+    @Autowired
+    private AutoServiceRegistrationProperties properties;
+    @Autowired
+    private Registration registration;
+
+    @Test
+    public void test() {
+        assertNotNull(serviceRegistry);
+        assertNotNull(registration);
+
+        serviceRegistry.register(registration);
+
+        while (true) {
+
+        }
+    }
+
+
+}

--- a/microsphere-spring-cloud-netflix-eureka-client/src/main/java/io/microsphere/spring/cloud/netflix/eureka/client/autoconfigure/EnhancedEurekaClientAutoConfiguration.java
+++ b/microsphere-spring-cloud-netflix-eureka-client/src/main/java/io/microsphere/spring/cloud/netflix/eureka/client/autoconfigure/EnhancedEurekaClientAutoConfiguration.java
@@ -19,6 +19,7 @@ package io.microsphere.spring.cloud.netflix.eureka.client.autoconfigure;
 import com.netflix.appinfo.ApplicationInfoManager;
 import com.netflix.appinfo.InstanceInfo;
 import com.netflix.discovery.EurekaClient;
+import io.microsphere.spring.cloud.client.service.registry.MultipleRegistration;
 import io.microsphere.spring.cloud.client.service.registry.event.RegistrationPreRegisteredEvent;
 import io.microsphere.spring.cloud.netflix.eureka.client.ConditionalOnEurekaClientEnabled;
 import io.microsphere.spring.guice.annotation.EnableGuice;
@@ -53,6 +54,13 @@ public class EnhancedEurekaClientAutoConfiguration {
     @EventListener(RegistrationPreRegisteredEvent.class)
     public void onRegistrationPreRegisteredEvent(RegistrationPreRegisteredEvent event) {
         Registration registration = event.getRegistration();
+        if (registration instanceof MultipleRegistration) {
+            registration = ((MultipleRegistration) registration).special(EurekaRegistration.class);
+        }
+
+        if (registration == null)
+            return;
+
         if (registration instanceof EurekaRegistration) {
             EurekaRegistration eurekaRegistration = (EurekaRegistration) registration;
             ApplicationInfoManager applicationInfoManager = eurekaRegistration.getApplicationInfoManager();

--- a/microsphere-spring-cloud-netflix-eureka-client/src/test/java/io/microsphere/spring/cloud/netflix/eureka/client/autoconfigure/EnhancedEurekaClientAutoConfigurationTest.java
+++ b/microsphere-spring-cloud-netflix-eureka-client/src/test/java/io/microsphere/spring/cloud/netflix/eureka/client/autoconfigure/EnhancedEurekaClientAutoConfigurationTest.java
@@ -19,9 +19,13 @@ package io.microsphere.spring.cloud.netflix.eureka.client.autoconfigure;
 import com.netflix.appinfo.HealthCheckHandler;
 import com.netflix.discovery.EurekaEventListener;
 import com.netflix.discovery.PreRegistrationHandler;
+import io.microsphere.spring.cloud.client.service.registry.autoconfigure.ServiceRegistryAutoConfiguration;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.cloud.client.serviceregistry.AutoServiceRegistrationAutoConfiguration;
+import org.springframework.cloud.client.serviceregistry.Registration;
 import org.springframework.cloud.netflix.eureka.server.EnableEurekaServer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.test.context.ContextConfiguration;
@@ -41,21 +45,31 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = {
+        AutoServiceRegistrationAutoConfiguration.class,
         EnhancedEurekaClientAutoConfigurationTest.class,
-        EnhancedEurekaClientAutoConfigurationTest.Config.class
+        EnhancedEurekaClientAutoConfigurationTest.Config.class,
+        ServiceRegistryAutoConfiguration.class,
+
 })
 @TestPropertySource(
         properties = {
                 "spring.application.name=test-eureka",
                 "server.port=12345",
-                "eureka.client.serviceUrl.defaultZone=http://127.0.0.1:12345/eureka"
+                "eureka.client.serviceUrl.defaultZone=http://127.0.0.1:12345/eureka",
+                "microsphere.spring.cloud.multiple-registration.enabled=true",
+                "microsphere.spring.cloud.default-registration.type=org.springframework.cloud.netflix.eureka.serviceregistry.EurekaRegistration",
+                "microsphere.spring.cloud.default-service-registry.type=org.springframework.cloud.netflix.eureka.serviceregistry.EurekaServiceRegistry",
+
         }
 )
 @EnableAutoConfiguration
-@EnableEurekaServer
+//@EnableEurekaServer
 public class EnhancedEurekaClientAutoConfigurationTest {
 
     private static final AtomicBoolean preRegistered = new AtomicBoolean(false);
+
+    @Autowired
+    private Registration registration;
 
     static class Config {
         @Bean
@@ -80,7 +94,11 @@ public class EnhancedEurekaClientAutoConfigurationTest {
 
     @Test
     public void test() throws Throwable {
+        registration.getMetadata().put("key", "value");
         Thread.sleep(TimeUnit.SECONDS.toMillis(1));
         assertTrue(preRegistered.get());
+        while (true) {
+
+        }
     }
 }


### PR DESCRIPTION
## Spring Cloud多注册实现
Spring Cloud并不支持多注册中心，现提供多注册中心支持，通过属性`microsphere.spring.cloud.multiple-registration.enabled`开启，默认关闭

### 注册信息共享`io.microsphere.spring.cloud.client.service.registry.MultipleRegistration`
不同的服务注册实现一般不一致，但是大多数情况下某些属性是相同的，比如`serviceId`,`host`,`port`等，因此需要指定某一种特定实现为默认实现，将这些数据共享至其余注册中心
```java
    @Override
    public String getServiceId() {
        return getDefaultRegistration().getServiceId();
    }

    @Override
    public String getHost() {
        return getDefaultRegistration().getHost();
    }

    @Override
    public int getPort() {
        return getDefaultRegistration().getPort();
    }

    @Override
    public boolean isSecure() {
        return getDefaultRegistration().isSecure();
    }

    @Override
    public URI getUri() {
        return getDefaultRegistration().getUri();
    }
```
通过配置属性`microsphere.spring.cloud.default-registration.type`指定默认实现，例如指定nacos时
`microsphere.spring.cloud.default-registration.type=com.alibaba.cloud.nacos.registry.NacosRegistration`

### 注册元数据共享`io.microsphere.spring.cloud.client.service.registry.RegistrationMetaData`
目前暂不支持注册实例的元数据信息隔离，因此，多个注册中心会共享同一份元数据信息，并且添加/删除元信息也会同步到所有的注册中心
```java
 @Override
    public String put(String key, String value) {
        synchronized (lock) {
            this.registrations.forEach(registration -> {
                registration.getMetadata().put(key, value);
            });
        }
        return this.applicationMetaData.put(key, value);
    }

    @Override
    public String remove(Object key) {
        synchronized (lock) {
            this.registrations.forEach(registration -> {
                registration.getMetadata().remove(key);
            });
        }
        return this.applicationMetaData.remove(key);
    }

    @Override
    public void putAll(Map<? extends String, ? extends String> m) {
        synchronized (lock) {
            this.registrations.forEach(registration -> {
                registration.getMetadata().putAll(m);
            });
        }
        this.applicationMetaData.putAll(m);
    }

    @Override
    public void clear() {
        synchronized (lock) {
            this.registrations.forEach(registration -> registration.getMetadata().clear());
        }
        this.applicationMetaData.clear();
    }
```

### 多注册中心组合`io.microsphere.spring.cloud.client.service.registry.MultipleServiceRegistry`
将多个注册中心实现，组合到一起，并标记为`@Primary`, 此时将同步代理所有`register`/`deregister`操作
```java
@Override
    public void register(MultipleRegistration registration) {
        this.registryMap.forEach((clazz, serviceRegistry) -> {
            Registration selectedRegistration = registration.special(clazz);
            if (selectedRegistration != null) {
                beforeRegister(serviceRegistry, selectedRegistration);
                serviceRegistry.register(selectedRegistration);
                afterRegister(serviceRegistry, selectedRegistration);
            }

        });
    }

    @Override
    public void deregister(MultipleRegistration registration) {
        this.registryMap.forEach((clazz, serviceRegistry) -> {
            Registration selectedRegistration = registration.special(clazz);
            if (selectedRegistration != null) {
                beforeDeregister(serviceRegistry, selectedRegistration);
                serviceRegistry.deregister(selectedRegistration);
                afterDeregister(serviceRegistry, selectedRegistration);
            }
        });
    }
```
针对`org.springframework.cloud.client.serviceregistry.ServiceRegistry#getStatus`操作，由于只能获取某一个注册中心的注册状态，因此需要外部指定默认注册中心实现，通过`microsphere.spring.cloud.default-service-registry.type`来指定。

当使用Nacos作为默认注册中心时：
`microsphere.spring.cloud.default-service-registry.type=com.alibaba.cloud.nacos.registry.NacosServiceRegistry`


### 注册/注销事件拦截
原有拦截注册/注销事件采用的aop的方式，当`io.microsphere.spring.cloud.client.service.registry.MultipleServiceRegistry`引入后，则可以在方法执行前后进行静态拦截