### PR TITLE
bug fix

### DIFF
--- a/microsphere-spring-cloud-commons/src/main/java/io/microsphere/spring/cloud/client/service/registry/MultipleRegistration.java
+++ b/microsphere-spring-cloud-commons/src/main/java/io/microsphere/spring/cloud/client/service/registry/MultipleRegistration.java
@@ -7,7 +7,6 @@ import java.net.URI;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 
 /**
  * The Delegating {@link Registration} for the multiple service registration

--- a/microsphere-spring-cloud-commons/src/main/java/io/microsphere/spring/cloud/client/service/registry/aspect/EventPublishingRegistrationAspect.java
+++ b/microsphere-spring-cloud-commons/src/main/java/io/microsphere/spring/cloud/client/service/registry/aspect/EventPublishingRegistrationAspect.java
@@ -61,6 +61,8 @@ public class EventPublishingRegistrationAspect implements ApplicationContextAwar
 
     @Before(value = REGISTER_POINTCUT_EXPRESSION, argNames = "registry, registration")
     public void beforeRegister(ServiceRegistry registry, Registration registration) {
+        if (registry.getClass().isAssignableFrom(MultipleServiceRegistry.class))
+            return;//Remove redundant register
         context.publishEvent(new RegistrationPreRegisteredEvent(registry, registration));
         registrationCustomizers.ifAvailable(customizer -> {
             customizer.customize(registration);
@@ -69,16 +71,22 @@ public class EventPublishingRegistrationAspect implements ApplicationContextAwar
 
     @Before(value = DEREGISTER_POINTCUT_EXPRESSION, argNames = "registry, registration")
     public void beforeDeregister(ServiceRegistry registry, Registration registration) {
+        if (registry.getClass().isAssignableFrom(MultipleServiceRegistry.class))
+            return;//Remove redundant deregister
         context.publishEvent(new RegistrationPreDeregisteredEvent(registry, registration));
     }
 
     @After(value = REGISTER_POINTCUT_EXPRESSION, argNames = "registry, registration")
     public void afterRegister(ServiceRegistry registry, Registration registration) {
+        if (registry.getClass().isAssignableFrom(MultipleServiceRegistry.class))
+            return;//Remove redundant register
         context.publishEvent(new RegistrationRegisteredEvent(registry, registration));
     }
 
     @After(value = DEREGISTER_POINTCUT_EXPRESSION, argNames = "registry, registration")
     public void afterDeregister(ServiceRegistry registry, Registration registration) {
+        if (registry.getClass().isAssignableFrom(MultipleServiceRegistry.class))
+            return;//Remove redundant deregister
         context.publishEvent(new RegistrationDeregisteredEvent(registry, registration));
     }
 

--- a/microsphere-spring-cloud-commons/src/test/java/io/microsphere/spring/cloud/client/service/registry/MultipleServiceRegistryTest.java
+++ b/microsphere-spring-cloud-commons/src/test/java/io/microsphere/spring/cloud/client/service/registry/MultipleServiceRegistryTest.java
@@ -11,6 +11,7 @@ import io.microsphere.spring.cloud.client.service.registry.event.RegistrationPre
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.cloud.client.CommonsClientAutoConfiguration;
 import org.springframework.cloud.client.serviceregistry.AutoServiceRegistrationAutoConfiguration;
 import org.springframework.cloud.client.serviceregistry.AutoServiceRegistrationProperties;
@@ -21,6 +22,7 @@ import org.springframework.cloud.netflix.eureka.EurekaClientAutoConfiguration;
 import org.springframework.cloud.netflix.eureka.config.DiscoveryClientOptionalArgsConfiguration;
 import org.springframework.cloud.netflix.eureka.serviceregistry.EurekaRegistration;
 import org.springframework.context.ApplicationListener;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -56,6 +58,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
                 "eureka.client.service-url.defaultZone=http://127.0.0.1:12345/eureka",
         }
 )
+@EnableAutoConfiguration
 class MultipleServiceRegistryTest implements ApplicationListener<RegistrationPreRegisteredEvent> {
 
 


### PR DESCRIPTION
修复bug
1. 多注册场景下,NacosServiceRegistry由于aop代理导致无法获取正确的NacosRegistration类
2. getStatus时,调用MultipleRegistration.getDefaultRegistration时,获取到的对象可能会与defaultServiceRegistry不一致的情况
3. EventPublishingRegistrationAspect屏蔽MultipleServiceRegistry,减少事件发布频率