### PR TITLE
test:fix WebMvcServiceRegistryAutoConfigurationTest to pass

### DIFF
--- a/microsphere-spring-cloud-commons/src/test/java/io/microsphere/spring/cloud/client/service/registry/autoconfigure/WebMvcServiceRegistryAutoConfigurationTest.java
+++ b/microsphere-spring-cloud-commons/src/test/java/io/microsphere/spring/cloud/client/service/registry/autoconfigure/WebMvcServiceRegistryAutoConfigurationTest.java
@@ -37,7 +37,11 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 @SpringBootTest(
         classes = {WebMvcServiceRegistryAutoConfigurationTest.class},
         properties = {
-                "microsphere.spring.cloud.simple.enabled=true"
+                "microsphere.spring.cloud.simple.enabled=true",
+                "spring.cloud.kubernetes.enabled=false",
+                "kubernetes.informer.enabled=false",
+                "kubernetes.manifests.enabled=false",
+                "kubernetes.reconciler.enabled=false"
         },
         webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT
 )


### PR DESCRIPTION
修复testcase
由于加入spring-cloud和kubernetes-starter依赖，ApplicationContext会创建BootstrapApplicationContext，并且创建kubernetes相关组件（ApiClient CoreApi）时缺少配置，导致报错。
需要禁用下列组件：
1. @ConditionalOnKubernetesEnabled相关的Bean
2. KubernetesInformerAutoConfiguration
3. KubernetesManifestsAutoConfiguration

目前通过inline test properties解决

还可以通过bootstrap.yaml解决
```yaml
spring:
  cloud:
    kubernetes:
      enabled: false
kubernetes:
  informer:
    enabled: false
  manifests:
    enabled: false
  reconciler:
    enable: false
```