### PR TITLE
Release 0.1.2

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -44,7 +44,7 @@ jobs:
           -Drevision=${{ inputs.revision }}
           -Dgpg.skip=true
           deploy
-          --activate-profiles release,ci
+          --activate-profiles publish,ci
         env:
           MAVEN_USERNAME: ${{ secrets.OSS_SONATYPE_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSS_SONATYPE_PASSWORD }}

--- a/microsphere-spring-cloud-commons/src/main/java/io/microsphere/spring/cloud/client/service/util/ServiceInstanceUtils.java
+++ b/microsphere-spring-cloud-commons/src/main/java/io/microsphere/spring/cloud/client/service/util/ServiceInstanceUtils.java
@@ -33,11 +33,8 @@ import java.util.StringJoiner;
 
 import static io.microsphere.collection.ListUtils.newArrayList;
 import static io.microsphere.constants.SeparatorConstants.LINE_SEPARATOR;
-import static io.microsphere.constants.SymbolConstants.COLON;
 import static io.microsphere.constants.SymbolConstants.COMMA;
-import static io.microsphere.constants.SymbolConstants.DOUBLE_QUOTE;
 import static io.microsphere.constants.SymbolConstants.LEFT_SQUARE_BRACKET;
-import static io.microsphere.constants.SymbolConstants.RIGHT_CURLY_BRACE;
 import static io.microsphere.constants.SymbolConstants.RIGHT_SQUARE_BRACKET;
 import static io.microsphere.json.JSONUtils.jsonArray;
 import static io.microsphere.json.JSONUtils.readArray;
@@ -66,7 +63,7 @@ public class ServiceInstanceUtils extends BaseUtils {
     public static void attachMetadata(String contextPath, ServiceInstance serviceInstance, Collection<WebEndpointMapping> webEndpointMappings) {
         Map<String, String> metadata = serviceInstance.getMetadata();
         StringJoiner jsonBuilder = new StringJoiner(COMMA + LINE_SEPARATOR, LEFT_SQUARE_BRACKET, RIGHT_SQUARE_BRACKET);
-        webEndpointMappings.stream().map(mapping -> toJSON(mapping)).forEach(jsonBuilder::add);
+        webEndpointMappings.stream().map(WebEndpointMapping::toJSON).forEach(jsonBuilder::add);
         String json = jsonBuilder.toString();
         logger.trace("Web Endpoint Mappings JSON: \n{}", json);
         json = json.replace(LINE_SEPARATOR, EMPTY_STRING);
@@ -89,18 +86,6 @@ public class ServiceInstanceUtils extends BaseUtils {
         Map<String, String> metadata = serviceInstance.getMetadata();
         String encodedJSON = metadata.get(WEB_MAPPINGS_METADATA_NAME);
         return parseWebEndpointMappings(encodedJSON);
-    }
-
-    static String toJSON(WebEndpointMapping webEndpointMapping) {
-        // FIXME : Issue on WebEndpointMapping.toJSON()
-        String json = webEndpointMapping.toJSON();
-        StringBuilder jsonBuilder = new StringBuilder(json);
-        int startIndex = jsonBuilder.lastIndexOf(LINE_SEPARATOR);
-        int endIndex = jsonBuilder.indexOf(RIGHT_CURLY_BRACE, startIndex);
-        String kindItem = COMMA + LINE_SEPARATOR + DOUBLE_QUOTE + "kind" + DOUBLE_QUOTE + COLON +
-                DOUBLE_QUOTE + webEndpointMapping.getKind() + DOUBLE_QUOTE + LINE_SEPARATOR;
-        jsonBuilder.replace(startIndex, endIndex, kindItem);
-        return jsonBuilder.toString();
     }
 
     static List<WebEndpointMapping> parseWebEndpointMappings(String encodedJSON) {

--- a/microsphere-spring-cloud-commons/src/test/java/io/microsphere/spring/cloud/client/service/util/ServiceInstanceUtilsTest.java
+++ b/microsphere-spring-cloud-commons/src/test/java/io/microsphere/spring/cloud/client/service/util/ServiceInstanceUtilsTest.java
@@ -36,7 +36,6 @@ import static io.microsphere.spring.cloud.client.service.util.ServiceInstanceUti
 import static io.microsphere.spring.cloud.client.service.util.ServiceInstanceUtils.getWebEndpointMappings;
 import static io.microsphere.spring.cloud.client.service.util.ServiceInstanceUtils.parseWebEndpointMapping;
 import static io.microsphere.spring.cloud.client.service.util.ServiceInstanceUtils.parseWebEndpointMappings;
-import static io.microsphere.spring.cloud.client.service.util.ServiceInstanceUtils.toJSON;
 import static io.microsphere.spring.web.metadata.WebEndpointMapping.Kind.SERVLET;
 import static io.microsphere.spring.web.metadata.WebEndpointMapping.servlet;
 import static io.microsphere.util.StringUtils.EMPTY_STRING_ARRAY;
@@ -107,7 +106,7 @@ class ServiceInstanceUtilsTest {
     @Test
     void testParseWebEndpointMapping() {
         WebEndpointMapping webEndpointMapping = buildWebEndpointMapping(false);
-        String json = toJSON(webEndpointMapping);
+        String json = webEndpointMapping.toJSON();
         JSONObject jsonObject = jsonObject(json);
         WebEndpointMapping webEndpointMapping1 = parseWebEndpointMapping(jsonObject);
         assertEquals(webEndpointMapping, webEndpointMapping1);

--- a/microsphere-spring-cloud-parent/pom.xml
+++ b/microsphere-spring-cloud-parent/pom.xml
@@ -20,7 +20,7 @@
 
     <properties>
         <!-- BOM versions -->
-        <microsphere-spring-boot.version>0.1.3</microsphere-spring-boot.version>
+        <microsphere-spring-boot.version>0.1.4</microsphere-spring-boot.version>
         <testcontainers.version>1.21.3</testcontainers.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     </scm>
 
     <properties>
-        <revision>0.1.1-SNAPSHOT</revision>
+        <revision>0.1.2-SNAPSHOT</revision>
     </properties>
 
     <modules>


### PR DESCRIPTION
This pull request contains several updates focused on simplifying the `ServiceInstanceUtils` utility class, cleaning up related imports and test code, and updating project versioning and publishing profiles. The most significant change is the removal of the custom `toJSON` method in favor of using the `WebEndpointMapping.toJSON()` method directly, which streamlines the code and removes unnecessary complexity.

**Code simplification and cleanup:**

* Removed the custom `toJSON(WebEndpointMapping)` method from `ServiceInstanceUtils` and updated all usages to call `WebEndpointMapping.toJSON()` directly, simplifying the code and eliminating a workaround for a previous issue. [[1]](diffhunk://#diff-83dd427f267ea3e50c594332f60026f286129ba596e5dd5c74febe80ce034cbeL69-R66) [[2]](diffhunk://#diff-83dd427f267ea3e50c594332f60026f286129ba596e5dd5c74febe80ce034cbeL94-L105) [[3]](diffhunk://#diff-f0665f182d7e5d9a86f59ec4a85dbb7fa290b17f2881ed8e65e875d5c5ad2585L39) [[4]](diffhunk://#diff-f0665f182d7e5d9a86f59ec4a85dbb7fa290b17f2881ed8e65e875d5c5ad2585L110-R109)
* Cleaned up unused static imports in `ServiceInstanceUtils.java` to improve code readability.

**Build and versioning updates:**

* Changed the Maven profile used during publishing from `release` to `publish` in `.github/workflows/maven-publish.yml` to align with the correct publishing workflow.
* Updated `microsphere-spring-boot.version` in `microsphere-spring-cloud-parent/pom.xml` from `0.1.3` to `0.1.4`.
* Bumped the main project `revision` property in `pom.xml` from `0.1.1-SNAPSHOT` to `0.1.2-SNAPSHOT`.