### PR TITLE
Update Maven wrapper and parent version to 0.2.7

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,3 +1,3 @@
 wrapperVersion=3.3.4
 distributionType=only-script
-distributionUrl=https://maven.aliyun.com/repository/public/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip
+distributionUrl=https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.9.15/apache-maven-3.9.15-bin.zip

--- a/microsphere-spring-cloud-parent/pom.xml
+++ b/microsphere-spring-cloud-parent/pom.xml
@@ -20,7 +20,7 @@
 
     <properties>
         <!-- BOM versions -->
-        <microsphere-spring-boot.version>0.1.10</microsphere-spring-boot.version>
+        <microsphere-spring-boot.version>0.1.11</microsphere-spring-boot.version>
         <testcontainers.version>1.21.3</testcontainers.version>
         <!-- Testing -->
         <junit-jupiter.version>5.14.3</junit-jupiter.version>

--- a/microsphere-spring-cloud-parent/pom.xml
+++ b/microsphere-spring-cloud-parent/pom.xml
@@ -21,7 +21,7 @@
     <properties>
         <!-- BOM versions -->
         <microsphere-spring-boot.version>0.1.11</microsphere-spring-boot.version>
-        <testcontainers.version>1.21.3</testcontainers.version>
+        <testcontainers.version>1.21.4</testcontainers.version>
         <!-- Testing -->
         <junit-jupiter.version>5.14.3</junit-jupiter.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.github.microsphere-projects</groupId>
         <artifactId>microsphere-build</artifactId>
-        <version>0.2.6</version>
+        <version>0.2.7</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
This pull request updates several version numbers to keep the project dependencies and build tools current. The most important changes are:

Dependency and Build Tool Updates:

* Updated the Maven wrapper to use Maven version 3.9.15 instead of 3.9.9 in `.mvn/wrapper/maven-wrapper.properties`.
* Updated the parent project version from `0.2.6` to `0.2.7` in `pom.xml`.
* Updated the `microsphere-spring-boot` BOM version from `0.1.10` to `0.1.11` in `microsphere-spring-cloud-parent/pom.xml`.