### PR TITLE
Enhance CI workflows and automate release notes generation

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -8,6 +8,9 @@
 
 name: Maven Build
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ 'dev-1.x' ]
@@ -36,15 +39,13 @@ jobs:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
 
-      - name: Make mvnw executable
-        run: chmod +x mvnw
-
       - name: Build with Maven
         run: ./mvnw
           --batch-mode
           --update-snapshots
           --file pom.xml
           -Drevision=0.0.1-SNAPSHOT
+          -Dsurefire.useSystemClassLoader=false
           test
           --activate-profiles test,coverage,testcontainers,${{ matrix.maven-profile-spring-cloud }}
 

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -21,13 +21,15 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     if: ${{ inputs.revision }}
     steps:
       - name: Validate version format
         run: |
           if ! echo "${{ inputs.revision }}" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
-          echo "Error: version '${{ inputs.revision }}' does not match the required pattern major.minor.patch"
-          exit 1
+            echo "Error: version '${{ inputs.revision }}' does not match the required pattern major.minor.patch"
+            exit 1
           fi
 
       - name: Checkout Source
@@ -49,6 +51,7 @@ jobs:
           --update-snapshots
           --file pom.xml
           -Drevision=${{ inputs.revision }}
+          -Dsurefire.useSystemClassLoader=false
           -Dgpg.skip=true
           deploy
           --activate-profiles publish,ci
@@ -59,12 +62,12 @@ jobs:
           SIGN_KEY: ${{ secrets.OSS_SIGNING_KEY }}
           SIGN_KEY_PASS: ${{ secrets.OSS_SIGNING_PASSWORD }}
 
-
   release:
     runs-on: ubuntu-latest
     needs: build
     permissions:
       contents: write
+      models: read
     steps:
       - name: Checkout Source
         uses: actions/checkout@v5
@@ -82,14 +85,90 @@ jobs:
             git push origin ${{ inputs.revision }}
           fi
 
+      - name: Generate Release Notes with Copilot
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          CURRENT_TAG="${{ inputs.revision }}"
+
+          # Find the previous tag (the one before the current tag)
+          PREV_TAG=$(git describe --tags --abbrev=0 --exclude="${CURRENT_TAG}" HEAD 2>/dev/null || echo "")
+
+          # Collect commits between the previous tag and HEAD
+          if [ -n "$PREV_TAG" ]; then
+            COMMITS=$(git log --oneline "${PREV_TAG}..HEAD" 2>/dev/null || echo "No commits found")
+            SINCE_LABEL="$PREV_TAG"
+          else
+            COMMITS=$(git log --oneline -50 2>/dev/null || echo "No commits found")
+            SINCE_LABEL="the beginning"
+          fi
+
+          # Export for Python (avoids shell-escaping issues with multiline content)
+          export CURRENT_TAG_DATA="$CURRENT_TAG"
+          export PREV_TAG_DATA="$SINCE_LABEL"
+          export COMMITS_DATA="$COMMITS"
+
+          # Call GitHub Copilot via GitHub Models API and capture the summary
+          SUMMARY=$(python3 << 'PYEOF'
+          import json, os, urllib.request, sys
+
+          current_tag = os.environ['CURRENT_TAG_DATA']
+          prev_tag    = os.environ['PREV_TAG_DATA']
+          commits     = os.environ['COMMITS_DATA']
+          token       = os.environ['GH_TOKEN']
+
+          prompt = (
+              f"Generate concise release notes for version {current_tag}.\n\n"
+              f"Commits since {prev_tag}:\n{commits}\n\n"
+              "Format the output as markdown with sections for New Features, Bug Fixes, "
+              "and Other Changes (only include sections that have relevant commits). "
+              "Be concise and clear."
+          )
+
+          payload = json.dumps({
+              "model": "gpt-4o",
+              "messages": [{"role": "user", "content": prompt}]
+          }).encode()
+
+          req = urllib.request.Request(
+              "https://models.inference.ai.azure.com/chat/completions",
+              data=payload,
+              headers={
+                  "Content-Type": "application/json",
+                  "Authorization": f"Bearer {token}"
+              }
+          )
+
+          try:
+              with urllib.request.urlopen(req) as resp:
+                  data = json.loads(resp.read())
+                  print(data["choices"][0]["message"]["content"])
+          except Exception as e:
+              print(f"Failed to generate summary via Copilot: {e}", file=sys.stderr)
+              print(f"_Release notes generation failed. Raw commits since {prev_tag}:_\n\n```\n{commits}\n```")
+          PYEOF
+          )
+
+          # Append the summary (with version header) to release-notes.md
+          NOTES_FILE="release-notes.md"
+          if [ ! -f "$NOTES_FILE" ]; then
+            printf "# Release Notes\n\n" > "$NOTES_FILE"
+          fi
+          printf "## v%s\n\n%s\n\n" "$CURRENT_TAG" "$SUMMARY" >> "$NOTES_FILE"
+
+          # Write the current release notes to a temp file for the Create Release step
+          printf "%s" "$SUMMARY" > /tmp/current-release-notes.md
+
+          echo "Release notes generated and appended to $NOTES_FILE"
+
       - name: Create Release
         run: |
           if gh release view "v${{ inputs.revision }}" >/dev/null 2>&1; then
             echo "Release v${{ inputs.revision }} already exists, skipping."
           else
-            gh release create v${{ inputs.revision }} \
+            gh release create ${{ inputs.revision }} \
               --title "v${{ inputs.revision }}" \
-              --generate-notes \
+              --notes-file /tmp/current-release-notes.md \
               --latest
           fi
         env:
@@ -110,7 +189,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add pom.xml
+          git add pom.xml release-notes.md
           git diff --cached --quiet && echo "No changes to commit" || \
             git commit -m "chore: bump version to next patch after publishing ${{ inputs.revision }}" && git push
 

--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ pom.xml:
 
 | **Branches** | **Purpose**                                      | **Latest Version** |
 |--------------|--------------------------------------------------|--------------------|
-| **0.2.x**    | Compatible with Spring Cloud 2022.0.x - 2025.0.x | 0.2.10             |
-| **0.1.x**    | Compatible with Spring Cloud Hoxton - 2021.0.x   | 0.1.10             |
+| **0.2.x**    | Compatible with Spring Cloud 2022.0.x - 2025.0.x | 0.2.11             |
+| **0.1.x**    | Compatible with Spring Cloud Hoxton - 2021.0.x   | 0.1.11             |
 
 Then add the specific modules you need:
 

--- a/microsphere-spring-cloud-parent/pom.xml
+++ b/microsphere-spring-cloud-parent/pom.xml
@@ -20,7 +20,7 @@
 
     <properties>
         <!-- BOM versions -->
-        <microsphere-spring-boot.version>0.1.11</microsphere-spring-boot.version>
+        <microsphere-spring-boot.version>0.1.12</microsphere-spring-boot.version>
         <testcontainers.version>1.21.4</testcontainers.version>
         <!-- Testing -->
         <junit-jupiter.version>5.14.3</junit-jupiter.version>


### PR DESCRIPTION
This pull request introduces improvements to the Maven build and publish GitHub Actions workflows, automates release note generation using GitHub Copilot, and updates version references to reflect new releases. The changes enhance workflow security, reliability, and release documentation.

**CI/CD Workflow Improvements:**

* Added explicit `permissions` blocks to both `.github/workflows/maven-build.yml` and `.github/workflows/maven-publish.yml` for better security and compliance. [[1]](diffhunk://#diff-3666a4bb90aefcffb84f1e981faea3bf4a2b870836765640bc46a0d98b7773f2R11-R13) [[2]](diffhunk://#diff-a31c6ada558b9f058a611b68d3f9cb0b9a901072c89d38fddc03cf929ef01e8aR24-R25) [[3]](diffhunk://#diff-a31c6ada558b9f058a611b68d3f9cb0b9a901072c89d38fddc03cf929ef01e8aL62-R70)
* Updated Maven build and publish steps to include the `-Dsurefire.useSystemClassLoader=false` flag, improving test execution reliability in certain environments. [[1]](diffhunk://#diff-3666a4bb90aefcffb84f1e981faea3bf4a2b870836765640bc46a0d98b7773f2L39-R48) [[2]](diffhunk://#diff-a31c6ada558b9f058a611b68d3f9cb0b9a901072c89d38fddc03cf929ef01e8aR54)
* Removed redundant `chmod +x mvnw` step from the build workflow, streamlining the process.

**Release Automation Enhancements:**

* Implemented an automated release notes generation step in the `maven-publish.yml` workflow using GitHub Copilot via the Models API. This step summarizes commit history between releases and appends the notes to `release-notes.md`, which is then used in the GitHub release.
* Modified the release creation step to use the generated release notes file instead of auto-generated notes.
* Ensured that `release-notes.md` is committed and pushed after publishing a new release.

**Version Updates:**

* Updated version references in `README.md` to `0.2.11` and `0.1.11` for the respective branches.
* Bumped the `microsphere-spring-boot.version` property in `microsphere-spring-cloud-parent/pom.xml` to `0.1.12`.