### PR TITLE
Enhance release notes generation and update release commands

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -120,8 +120,9 @@ jobs:
           prompt = (
               f"Generate concise release notes for version {current_tag}.\n\n"
               f"Commits since {prev_tag}:\n{commits}\n\n"
-              "Format the output as markdown with sections for New Features, Bug Fixes, "
-              "and Other Changes (only include sections that have relevant commits). "
+              "Format the output as markdown with sections if present for New Features, Bug Fixes, "
+              "Documentations, Dependency Updates, Test Improvements, Build and Workflow Enhancements "
+              "and Other Changes(excludes Full Changelog).\n\n"
               "Be concise and clear."
           )
 
@@ -154,20 +155,25 @@ jobs:
           if [ ! -f "$NOTES_FILE" ]; then
             printf "# Release Notes\n\n" > "$NOTES_FILE"
           fi
+          
+          FULL_CHANGELOG="**Full Changelog**: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/compare/$PREV_TAG...$CURRENT_TAG"
+          
           printf "## v%s\n\n%s\n\n" "$CURRENT_TAG" "$SUMMARY" >> "$NOTES_FILE"
-
+          printf "%s" "$FULL_CHANGELOG" >> "$NOTES_FILE"
+          
           # Write the current release notes to a temp file for the Create Release step
-          printf "%s" "$SUMMARY" > /tmp/current-release-notes.md
+          printf "%s\n\n" "$SUMMARY" > /tmp/current-release-notes.md
+          printf "%s" "$FULL_CHANGELOG" >> /tmp/current-release-notes.md
 
           echo "Release notes generated and appended to $NOTES_FILE"
 
       - name: Create Release
         run: |
-          if gh release view "v${{ inputs.revision }}" >/dev/null 2>&1; then
-            echo "Release v${{ inputs.revision }} already exists, skipping."
+          if gh release view "${{ inputs.revision }}" >/dev/null 2>&1; then
+            echo "Release ${{ inputs.revision }} already exists, skipping."
           else
             gh release create ${{ inputs.revision }} \
-              --title "v${{ inputs.revision }}" \
+              --title "${{ inputs.revision }}" \
               --notes-file /tmp/current-release-notes.md \
               --latest
           fi


### PR DESCRIPTION
This pull request updates the release note generation process in the `.github/workflows/maven-publish.yml` workflow to improve the clarity and completeness of release notes. The changes expand the categorization of release note sections, ensure the full changelog link is always included, and make minor consistency improvements to release creation.

Release note generation improvements:

* Expanded the release note prompt to include additional sections: Documentations, Dependency Updates, Test Improvements, and Build and Workflow Enhancements, alongside the existing New Features, Bug Fixes, and Other Changes. The prompt now specifies to exclude the Full Changelog from these sections.
* The generated release notes now always append a **Full Changelog** link, both to the persistent release notes file and to the temporary file used for the GitHub release, ensuring users can easily find the complete list of changes.

Workflow consistency:

* Minor adjustments to the release creation step for consistent variable usage and output formatting.