### PR TITLE
Improve CI Java setup and update Maven dependencies

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -33,14 +33,15 @@ jobs:
         with:
           token: ${{ secrets.TC_CLOUD_TOKEN }}
 
-      - name: Setup JDK ${{ matrix.Java }}
+      - name: Setup Java ${{ matrix.java }}
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
+          cache: maven
 
       - name: Build with Maven
-        run: ./mvnw
+        run: mvn
           --batch-mode
           --update-snapshots
           --file pom.xml

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -40,13 +40,9 @@ jobs:
         with:
           java-version: '11'
           distribution: 'temurin'
-          server-id: ossrh
-          server-username: MAVEN_USERNAME
-          server-password: MAVEN_PASSWORD
-          cache: maven
 
       - name: Publish package
-        run: mvn
+        run: ./mvnw
           --batch-mode
           --update-snapshots
           --file pom.xml

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -40,6 +40,9 @@ jobs:
         with:
           java-version: '11'
           distribution: 'temurin'
+          server-id: ossrh
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
 
       - name: Publish package
         run: ./mvnw

--- a/microsphere-spring-cloud-parent/pom.xml
+++ b/microsphere-spring-cloud-parent/pom.xml
@@ -20,7 +20,7 @@
 
     <properties>
         <!-- BOM versions -->
-        <microsphere-spring-boot.version>0.1.12</microsphere-spring-boot.version>
+        <microsphere-spring-boot.version>0.1.13</microsphere-spring-boot.version>
         <testcontainers.version>1.21.4</testcontainers.version>
         <!-- Testing -->
         <junit-jupiter.version>5.14.4</junit-jupiter.version>

--- a/microsphere-spring-cloud-parent/pom.xml
+++ b/microsphere-spring-cloud-parent/pom.xml
@@ -23,7 +23,7 @@
         <microsphere-spring-boot.version>0.1.12</microsphere-spring-boot.version>
         <testcontainers.version>1.21.4</testcontainers.version>
         <!-- Testing -->
-        <junit-jupiter.version>5.14.3</junit-jupiter.version>
+        <junit-jupiter.version>5.14.4</junit-jupiter.version>
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.github.microsphere-projects</groupId>
         <artifactId>microsphere-build</artifactId>
-        <version>0.2.7</version>
+        <version>0.2.9</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
This pull request updates dependencies and improves the Maven build and publish workflows. The main changes include upgrading several version numbers in `pom.xml` files and adjusting the GitHub Actions workflows for more consistent and efficient Java setup and Maven usage.

Dependency and version updates:

* Upgraded the parent POM version in `pom.xml` from `0.2.7` to `0.2.9`.
* Updated `microsphere-spring-boot.version` to `0.1.13` and `junit-jupiter.version` to `5.14.4` in `microsphere-spring-cloud-parent/pom.xml`.

GitHub Actions workflow improvements:

* In `.github/workflows/maven-build.yml`, changed the Java setup step to use the correct matrix variable, enabled Maven caching, and switched from `./mvnw` to the system `mvn` command for building.
* In `.github/workflows/maven-publish.yml`, removed Maven caching from the setup-java step and switched from `mvn` to `./mvnw` for publishing, ensuring the wrapper is used for consistency.