### PR TITLE
Update microsphere-spring-boot version and README documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,8 @@ Then declare only the modules you need (versions are managed by the BOM):
 
 | **Branch** | **Spring Cloud compatibility**         | **Latest version** |
 |------------|----------------------------------------|--------------------|
-| `main`     | 2022.0.x, 2023.0.x, 2024.0.x, 2025.0.x | `0.2.18`           |
-| `1.x`      | Hoxton, 2020.0.x, 2021.0.x             | `0.1.18`           |
+| `main`     | 2022.0.x, 2023.0.x, 2024.0.x, 2025.0.x | `0.2.19`           |
+| `1.x`      | Hoxton, 2020.0.x, 2021.0.x             | `0.1.19`           |
 
 By default, the `main` branch builds against Spring Cloud 2025.0.x. To build or run tests against an older generation,
 activate the corresponding Maven profile:

--- a/microsphere-spring-cloud-parent/pom.xml
+++ b/microsphere-spring-cloud-parent/pom.xml
@@ -20,7 +20,7 @@
 
     <properties>
         <!-- BOM versions -->
-        <microsphere-spring-boot.version>0.1.21</microsphere-spring-boot.version>
+        <microsphere-spring-boot.version>0.1.22</microsphere-spring-boot.version>
         <testcontainers.version>1.21.4</testcontainers.version>
         <!-- Testing -->
         <junit-jupiter.version>5.14.4</junit-jupiter.version>


### PR DESCRIPTION
This pull request updates version numbers to keep dependencies and documentation in sync with the latest releases.

Dependency and documentation version updates:

* Updated the `microsphere-spring-boot.version` property to `0.1.22` in `microsphere-spring-cloud-parent/pom.xml`.
* Updated the documented latest versions for the `main` and `1.x` branches in `README.md` to `0.2.19` and `0.1.19`, respectively.