### PR TITLE
Update microsphere-spring-boot version and enhance feature utilities

### DIFF
--- a/microsphere-spring-cloud-commons/src/main/java/io/microsphere/spring/cloud/client/actuator/ConfigurationPropertyHasFeaturesAutoConfiguration.java
+++ b/microsphere-spring-cloud-commons/src/main/java/io/microsphere/spring/cloud/client/actuator/ConfigurationPropertyHasFeaturesAutoConfiguration.java
@@ -18,44 +18,47 @@
 package io.microsphere.spring.cloud.client.actuator;
 
 import io.microsphere.logging.Logger;
+import io.microsphere.spring.cloud.client.actuator.constants.FeaturesConstants;
 import io.microsphere.spring.cloud.client.condition.ConditionalOnFeaturesAvailable;
 import io.microsphere.spring.context.config.AutoRegistrationBean;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanClassLoaderAware;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
-import org.springframework.beans.factory.config.SingletonBeanRegistry;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.client.actuator.HasFeatures;
 import org.springframework.cloud.client.actuator.NamedFeature;
-import org.springframework.context.EnvironmentAware;
-import org.springframework.core.env.ConfigurableEnvironment;
-import org.springframework.core.env.Environment;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 
-import static io.microsphere.collection.ListUtils.newLinkedList;
+import static io.microsphere.collection.ListUtils.ofList;
 import static io.microsphere.collection.MapUtils.newLinkedHashMap;
-import static io.microsphere.constants.PropertyConstants.MICROSPHERE_PROPERTY_NAME_PREFIX;
-import static io.microsphere.constants.SymbolConstants.COMMA_CHAR;
-import static io.microsphere.constants.SymbolConstants.DOT;
-import static io.microsphere.constants.SymbolConstants.DOT_CHAR;
+import static io.microsphere.collection.SetUtils.newLinkedHashSet;
+import static io.microsphere.collection.SetUtils.newTreeSet;
 import static io.microsphere.logging.LoggerFactory.getLogger;
-import static io.microsphere.spring.cloud.commons.constants.CommonsPropertyConstants.MICROSPHERE_SPRING_CLOUD_PROPERTY_NAME_PREFIX;
-import static io.microsphere.spring.core.env.EnvironmentUtils.asConfigurableEnvironment;
-import static io.microsphere.spring.core.env.PropertySourcesUtils.getSubProperties;
+import static io.microsphere.spring.beans.BeanSource.BEAN_FACTORY;
+import static io.microsphere.spring.beans.factory.BeanFactoryUtils.asDefaultListableBeanFactory;
+import static io.microsphere.spring.cloud.client.actuator.FeaturesUtils.getAbstractFeaturePropertyName;
+import static io.microsphere.spring.cloud.client.actuator.FeaturesUtils.getHasFeaturesBeanName;
+import static io.microsphere.spring.cloud.client.actuator.FeaturesUtils.getNamedFeaturePropertyName;
+import static io.microsphere.spring.cloud.client.actuator.FeaturesUtils.getQualifierFeatureName;
+import static io.microsphere.spring.cloud.client.actuator.NamedFeatureComparator.INSTANCE;
 import static io.microsphere.text.FormatUtils.format;
 import static io.microsphere.util.ClassLoaderUtils.resolveClass;
-import static io.microsphere.util.StringUtils.split;
-import static java.lang.String.valueOf;
+import static io.microsphere.util.ClassUtils.getSimpleName;
 
 /**
  * Auto-registrar for Spring Cloud Client Actuator's {@link HasFeatures} based on configuration properties.
  * <p>
- * This class scans configuration properties under the prefix {@value #PROPERTY_PREFIX} to automatically register
- * {@link HasFeatures} beans. It supports two types of feature definitions:
+ * This class scans configuration properties under the prefix {@value FeaturesConstants#PROPERTY_NAME_PREFIX} to
+ * automatically register {@link HasFeatures} beans. It supports two types of feature definitions:
  * <ul>
  *     <li><strong>Abstract Features:</strong> Defined by listing feature classes directly under a module name.</li>
  *     <li><strong>Named Features:</strong> Defined by mapping a specific feature name to a feature class under a module name.</li>
@@ -66,13 +69,13 @@ import static java.lang.String.valueOf;
  * <h4>1. Abstract Features</h4>
  * <pre>{@code
  * # Defines abstract features for the 'jdbc' module
- * microsphere.spring.cloud.features.jdbc=org.springframework.jdbc.core.JdbcTemplate,org.springframework.transaction.PlatformTransactionManager
+ * microsphere.spring.cloud.features.abstract.jdbc=org.springframework.jdbc.core.JdbcTemplate,org.springframework.transaction.PlatformTransactionManager
  * }</pre>
  *
  * <h4>2. Named Features</h4>
  * <pre>{@code
  * # Defines a named feature 'rest-template' for the 'web' module
- * microsphere.spring.cloud.features.web.rest-template=org.springframework.web.client.RestTemplate
+ * microsphere.spring.cloud.features.named.web.rest-template=org.springframework.web.client.RestTemplate
  * }</pre>
  *
  * <h3>Resulting Beans</h3>
@@ -87,38 +90,17 @@ import static java.lang.String.valueOf;
  */
 @ConditionalOnFeaturesAvailable
 @AutoConfigureBefore(name = "org.springframework.cloud.client.CommonsClientAutoConfiguration")
-public class ConfigurationPropertyHasFeaturesAutoConfiguration implements BeanFactoryAware, BeanClassLoaderAware,
-        EnvironmentAware {
+@EnableConfigurationProperties(FeaturesProperties.class)
+public class ConfigurationPropertyHasFeaturesAutoConfiguration implements BeanFactoryAware, BeanClassLoaderAware, InitializingBean {
 
     private static final Logger logger = getLogger(ConfigurationPropertyHasFeaturesAutoConfiguration.class);
 
-    static final String NAME = "features";
-
-    /**
-     * The prefix of the configuration properties for {@link HasFeatures} : "microsphere.spring.cloud.features."
-     */
-    public static final String PROPERTY_PREFIX = MICROSPHERE_SPRING_CLOUD_PROPERTY_NAME_PREFIX + NAME + DOT;
-
-    /**
-     * The pattern of the configuration properties for abstract features: "microsphere.spring.cloud.features.{module-name}"
-     */
-    public static final String ABSTRACT_FEATURE_PROPERTY_NAME_PATTERN = PROPERTY_PREFIX + "{}";
-
-    /**
-     * The pattern of the configuration properties for named features: "microsphere.spring.cloud.features.{module-name}.{feature-name}"
-     */
-    public static final String NAMED_FEATURE_PROPERTY_NAME_PATTERN = ABSTRACT_FEATURE_PROPERTY_NAME_PATTERN + DOT + "{}";
-
-    /**
-     * The suffix of the bean name for {@link HasFeatures} : ".features"
-     */
-    public static final String BEAN_NAME_SUFFIX = DOT + NAME;
-
     private ClassLoader classLoader;
 
-    private SingletonBeanRegistry singletonBeanRegistry;
+    private DefaultListableBeanFactory beanFactory;
 
-    private final Map<String, ModuleFeatures> moduleFeaturesMap = newLinkedHashMap();
+    @Autowired
+    private FeaturesProperties featuresProperties;
 
     @Override
     public void setBeanClassLoader(ClassLoader classLoader) {
@@ -127,141 +109,112 @@ public class ConfigurationPropertyHasFeaturesAutoConfiguration implements BeanFa
 
     @Override
     public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
-        this.singletonBeanRegistry = (SingletonBeanRegistry) beanFactory;
+        this.beanFactory = asDefaultListableBeanFactory(beanFactory);
     }
 
     @Override
-    public void setEnvironment(Environment environment) {
-        ConfigurableEnvironment env = asConfigurableEnvironment(environment);
-        Map<String, Object> subProperties = getSubProperties(env, PROPERTY_PREFIX);
-        for (Entry<String, Object> entry : subProperties.entrySet()) {
-            String key = entry.getKey();
-            String value = valueOf(entry.getValue());
-            int index = key.indexOf(DOT_CHAR);
-            boolean isAbstract = index == -1;
-            if (isAbstract) {
-                String[] featureClassNames = split(value, COMMA_CHAR);
-                String moduleName = key;
-                addAbstractFeatureClassNames(moduleName, featureClassNames);
-            } else {
-                String moduleName = key.substring(0, index);
-                String featureName = key.substring(index + 1);
-                String featureClassName = value;
-                addNamedFeatureClassName(moduleName, featureName, featureClassName);
+    public void afterPropertiesSet() {
+        FeaturesProperties featuresProperties = this.featuresProperties;
+
+        Map<String, ModuleFeatures> moduleFeaturesMap = newLinkedHashMap();
+        Map<String, List<String>> abstractProperties = featuresProperties.getAbstract();
+
+        abstractProperties.forEach((moduleName, featureClassNames) -> {
+            addAbstractFeatureClassNames(moduleName, featureClassNames, moduleFeaturesMap);
+        });
+
+        Map<String, Map<String, String>> namedProperties = featuresProperties.getNamed();
+
+        namedProperties.forEach((moduleName, namedFeatures) -> {
+            for (Entry<String, String> entry : namedFeatures.entrySet()) {
+                String featureName = entry.getKey();
+                String featureClassName = entry.getValue();
+                addNamedFeatureClassName(moduleName, featureName, featureClassName, moduleFeaturesMap);
             }
-        }
-        registerHasFeaturesBeans();
+        });
+
+        registerHasFeaturesBeans(moduleFeaturesMap);
+        moduleFeaturesMap.clear();
     }
 
-    /**
-     * Gets the configuration property name for abstract features of the specified module.
-     * <h3>Example Usage</h3>
-     * <pre>{@code
-     * // For module name "jdbc"
-     * String propertyName = getAbstractFeaturePropertyName("jdbc");
-     * // Result: "microsphere.spring.cloud.features.jdbc"
-     * }</pre>
-     *
-     * @param moduleName the name of the module
-     * @return the configuration property name for abstract features
-     */
-    public static String getAbstractFeaturePropertyName(String moduleName) {
-        return format(ABSTRACT_FEATURE_PROPERTY_NAME_PATTERN, moduleName);
-    }
-
-    /**
-     * Gets the configuration property name for a named feature of the specified module.
-     * <h3>Example Usage</h3>
-     * <pre>{@code
-     * // For module name "web" and feature name "rest-template"
-     * String propertyName = getNamedFeaturePropertyName("web", "rest-template");
-     * // Result: "microsphere.spring.cloud.features.web.rest-template"
-     * }</pre>
-     *
-     * @param moduleName  the name of the module
-     * @param featureName the name of the feature
-     * @return the configuration property name for the named feature
-     */
-    public static String getNamedFeaturePropertyName(String moduleName, String featureName) {
-        return format(NAMED_FEATURE_PROPERTY_NAME_PATTERN, moduleName, featureName);
-    }
-
-    /**
-     * Gets the bean name for {@link HasFeatures} of the specified module.
-     * <h3>Example Usage</h3>
-     * <pre>{@code
-     * // For module name "jdbc"
-     * String beanName = getBeanName("jdbc");
-     * // Result: "jdbc.features"
-     * }</pre>
-     *
-     * @param moduleName the name of the module
-     * @return the bean name for {@link HasFeatures}
-     */
-    public static String getBeanName(String moduleName) {
-        return moduleName + BEAN_NAME_SUFFIX;
-    }
-
-    /**
-     * Gets the qualified feature name for a named feature of the specified module.
-     * <h3>Example Usage</h3>
-     * <pre>{@code
-     * // For module name "web" and feature name "rest-template"
-     * String qualifiedName = getQualifierFeatureName("web", "rest-template");
-     * // Result: "microsphere.web.rest-template"
-     * }</pre>
-     *
-     * @param moduleName  the name of the module
-     * @param featureName the name of the feature
-     * @return the qualified feature name
-     */
-    public static String getQualifierFeatureName(String moduleName, String featureName) {
-        return MICROSPHERE_PROPERTY_NAME_PREFIX + moduleName + DOT_CHAR + featureName;
-    }
-
-    private void addAbstractFeatureClassNames(String moduleName, String[] featureClassNames) {
-        ModuleFeatures moduleFeatures = getModuleFeatures(moduleName);
+    private void addAbstractFeatureClassNames(String moduleName, List<String> featureClassNames, Map<String, ModuleFeatures> moduleFeaturesMap) {
         for (String featureClassName : featureClassNames) {
-            Class<?> featureClass = loadClass(featureClassName);
-            if (featureClass == null) {
-                String propertyName = getAbstractFeaturePropertyName(moduleName);
-                logger.warn("The class of abstract feature[class : '{}'] is not found in classpath, please check the configuration property : '{}'",
-                        featureClassName, propertyName);
-                continue;
-            }
-            moduleFeatures.abstractFeatures.add(featureClass);
+            addAbstractFeatureClassName(moduleName, featureClassName, moduleFeaturesMap);
         }
     }
 
-    private void addNamedFeatureClassName(String moduleName, String featureName, String featureClassName) {
-        ModuleFeatures moduleFeatures = getModuleFeatures(moduleName);
-        String name = getQualifierFeatureName(moduleName, featureName);
+    private void addAbstractFeatureClassName(String moduleName, String featureClassName, Map<String, ModuleFeatures> moduleFeaturesMap) {
         Class<?> featureClass = loadClass(featureClassName);
         if (featureClass == null) {
-            String propertyName = getNamedFeaturePropertyName(moduleName, featureName);
+            logger.warn("The class of AbstractFeature[class : '{}'] is not found in classpath, please check the configuration property : '{}'",
+                    featureClassName, getAbstractFeaturePropertyName(moduleName));
+            return;
+        }
+
+        Set<Class<?>> beanTypes = getBeanTypes(featureClass);
+        if (beanTypes.isEmpty()) { // No bean type found
+            addAbstractFeatureClass(moduleName, featureClass, moduleFeaturesMap);
+        } else {
+            for (Class<?> beanType : beanTypes) {
+                addNamedFeatureClass(moduleName, beanType, moduleFeaturesMap);
+            }
+        }
+    }
+
+    private void addNamedFeatureClassName(String moduleName, String featureName, String featureClassName, Map<String, ModuleFeatures> moduleFeaturesMap) {
+        String name = getQualifierFeatureName(moduleName, featureName);
+        Class<?> featureClass = loadClass(featureClassName);
+        String propertyName = getNamedFeaturePropertyName(moduleName, featureName);
+        if (featureClass == null) {
             logger.warn("The class of named feature[name : '{}' , class : '{}'] is not found in classpath, please check the configuration property : '{}'",
                     name, featureClassName, propertyName);
             return;
         }
+
+        addNamedFeatureClass(moduleName, featureName, featureClass, moduleFeaturesMap);
+    }
+
+    private Set<Class<?>> getBeanTypes(Class<?> featureClass) {
+        return (Set) BEAN_FACTORY.getBeanTypes(this.beanFactory, featureClass);
+    }
+
+    private void addAbstractFeatureClass(String moduleName, Class<?> featureClass, Map<String, ModuleFeatures> moduleFeaturesMap) {
+        ModuleFeatures moduleFeatures = getModuleFeatures(moduleFeaturesMap, moduleName);
+        logger.trace("The AbstractFeature[module : '{}' , class : '{}'] will be added in the HasFeatures.", moduleName,
+                featureClass.getName());
+        moduleFeatures.abstractFeatures.add(featureClass);
+    }
+
+    private void addNamedFeatureClass(String moduleName, Class<?> featureClass, Map<String, ModuleFeatures> moduleFeaturesMap) {
+        String featureName = getSimpleName(featureClass);
+        addNamedFeatureClass(moduleName, featureName, featureClass, moduleFeaturesMap);
+    }
+
+    private void addNamedFeatureClass(String moduleName, String featureName, Class<?> featureClass, Map<String, ModuleFeatures> moduleFeaturesMap) {
+        String name = getQualifierFeatureName(moduleName, featureName);
         NamedFeature namedFeature = new NamedFeature(name, featureClass);
+        ModuleFeatures moduleFeatures = getModuleFeatures(moduleFeaturesMap, moduleName);
+        logger.trace("The NamedFeature[module : '{}' , name : '{}' , class : '{}'] will be added in the HasFeatures.",
+                moduleName, name, featureClass.getName());
         moduleFeatures.namedFeatures.add(namedFeature);
     }
+
 
     private Class<?> loadClass(String className) {
         return resolveClass(className, this.classLoader);
     }
 
-    private ModuleFeatures getModuleFeatures(String moduleName) {
-        return this.moduleFeaturesMap.computeIfAbsent(moduleName, ModuleFeatures::new);
+    private ModuleFeatures getModuleFeatures(Map<String, ModuleFeatures> moduleFeaturesMap, String moduleName) {
+        return moduleFeaturesMap.computeIfAbsent(moduleName, ModuleFeatures::new);
     }
 
-    private void registerHasFeaturesBeans() {
-        for (Entry<String, ModuleFeatures> entry : this.moduleFeaturesMap.entrySet()) {
+    private void registerHasFeaturesBeans(Map<String, ModuleFeatures> moduleFeaturesMap) {
+        for (Entry<String, ModuleFeatures> entry : moduleFeaturesMap.entrySet()) {
             String moduleName = entry.getKey();
             ModuleFeatures moduleFeatures = entry.getValue();
             HasFeatures hasFeatures = moduleFeatures.toHasFeatures();
-            String beanName = getBeanName(moduleName);
-            this.singletonBeanRegistry.registerSingleton(beanName, hasFeatures);
+            String beanName = getHasFeaturesBeanName(moduleName);
+            this.beanFactory.registerSingleton(beanName, hasFeatures);
         }
     }
 
@@ -269,9 +222,9 @@ public class ConfigurationPropertyHasFeaturesAutoConfiguration implements BeanFa
 
         private final String moduleName;
 
-        private final List<Class<?>> abstractFeatures = newLinkedList();
+        private final Set<Class<?>> abstractFeatures = newLinkedHashSet();
 
-        private final List<NamedFeature> namedFeatures = newLinkedList();
+        private final Set<NamedFeature> namedFeatures = newTreeSet(INSTANCE);
 
         ModuleFeatures(String moduleName) {
             this.moduleName = moduleName;
@@ -279,7 +232,7 @@ public class ConfigurationPropertyHasFeaturesAutoConfiguration implements BeanFa
 
         HasFeatures toHasFeatures() {
             logger.info(toString());
-            return new HasFeatures(this.abstractFeatures, this.namedFeatures);
+            return new HasFeatures(ofList(this.abstractFeatures), ofList(this.namedFeatures));
         }
 
         @Override

--- a/microsphere-spring-cloud-commons/src/main/java/io/microsphere/spring/cloud/client/actuator/FeaturesProperties.java
+++ b/microsphere-spring-cloud-commons/src/main/java/io/microsphere/spring/cloud/client/actuator/FeaturesProperties.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.microsphere.spring.cloud.client.actuator;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.cloud.client.actuator.FeaturesEndpoint;
+
+import java.util.List;
+import java.util.Map;
+
+import static io.microsphere.spring.cloud.client.actuator.constants.FeaturesConstants.PROPERTY_NAME_PREFIX;
+import static java.util.Collections.emptyMap;
+
+/**
+ * The {@link ConfigurationProperties} for {@link FeaturesEndpoint}
+ *
+ * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
+ * @see ConfigurationProperties
+ * @since 1.0.0
+ */
+@ConfigurationProperties(prefix = PROPERTY_NAME_PREFIX)
+public class FeaturesProperties {
+
+    private Map<String, List<String>> _abstract;
+
+    private Map<String, Map<String, String>> named;
+
+    public void setAbstract(Map<String, List<String>> _abstract) {
+        this._abstract = _abstract;
+    }
+
+    public Map<String, List<String>> getAbstract() {
+        if (_abstract == null) {
+            return emptyMap();
+        }
+        return _abstract;
+    }
+
+    public void setNamed(Map<String, Map<String, String>> named) {
+        this.named = named;
+    }
+
+    public Map<String, Map<String, String>> getNamed() {
+        if (named == null) {
+            return emptyMap();
+        }
+        return named;
+    }
+}

--- a/microsphere-spring-cloud-commons/src/main/java/io/microsphere/spring/cloud/client/actuator/FeaturesUtils.java
+++ b/microsphere-spring-cloud-commons/src/main/java/io/microsphere/spring/cloud/client/actuator/FeaturesUtils.java
@@ -20,8 +20,7 @@ package io.microsphere.spring.cloud.client.actuator;
 import io.microsphere.util.Utils;
 import org.springframework.cloud.client.actuator.HasFeatures;
 
-import static io.microsphere.constants.PropertyConstants.MICROSPHERE_PROPERTY_NAME_PREFIX;
-import static io.microsphere.constants.SymbolConstants.DOT_CHAR;
+import static io.microsphere.constants.SymbolConstants.COLON_CHAR;
 import static io.microsphere.spring.cloud.client.actuator.constants.FeaturesConstants.ABSTRACT_FEATURE_PROPERTY_NAME_PATTERN;
 import static io.microsphere.spring.cloud.client.actuator.constants.FeaturesConstants.BEAN_NAME_SUFFIX;
 import static io.microsphere.spring.cloud.client.actuator.constants.FeaturesConstants.NAMED_FEATURE_PROPERTY_NAME_PATTERN;
@@ -92,7 +91,7 @@ public abstract class FeaturesUtils implements Utils {
      * <pre>{@code
      * // For module name "web" and feature name "rest-template"
      * String qualifiedName = getQualifierFeatureName("web", "rest-template");
-     * // Result: "microsphere.web.rest-template"
+     * // Result: "web:rest-template"
      * }</pre>
      *
      * @param moduleName  the name of the module
@@ -100,7 +99,7 @@ public abstract class FeaturesUtils implements Utils {
      * @return the qualified feature name
      */
     public static String getQualifierFeatureName(String moduleName, String featureName) {
-        return MICROSPHERE_PROPERTY_NAME_PREFIX + moduleName + DOT_CHAR + featureName;
+        return moduleName + COLON_CHAR + featureName;
     }
 
     private FeaturesUtils() {

--- a/microsphere-spring-cloud-commons/src/main/java/io/microsphere/spring/cloud/client/actuator/FeaturesUtils.java
+++ b/microsphere-spring-cloud-commons/src/main/java/io/microsphere/spring/cloud/client/actuator/FeaturesUtils.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.microsphere.spring.cloud.client.actuator;
+
+import io.microsphere.util.Utils;
+import org.springframework.cloud.client.actuator.HasFeatures;
+
+import static io.microsphere.constants.PropertyConstants.MICROSPHERE_PROPERTY_NAME_PREFIX;
+import static io.microsphere.constants.SymbolConstants.DOT_CHAR;
+import static io.microsphere.spring.cloud.client.actuator.constants.FeaturesConstants.ABSTRACT_FEATURE_PROPERTY_NAME_PATTERN;
+import static io.microsphere.spring.cloud.client.actuator.constants.FeaturesConstants.BEAN_NAME_SUFFIX;
+import static io.microsphere.spring.cloud.client.actuator.constants.FeaturesConstants.NAMED_FEATURE_PROPERTY_NAME_PATTERN;
+import static io.microsphere.text.FormatUtils.format;
+
+/**
+ * The {@link Utils utilities} class for Spring Cloud {@link HasFeatures features}
+ *
+ * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
+ * @see HasFeatures
+ * @see Utils
+ * @since 1.0.0
+ */
+public abstract class FeaturesUtils implements Utils {
+
+    /**
+     * Gets the configuration property name for abstract features of the specified module.
+     * <h3>Example Usage</h3>
+     * <pre>{@code
+     * // For module name "jdbc"
+     * String propertyName = getAbstractFeaturePropertyName("jdbc");
+     * // Result: "microsphere.spring.cloud.features.abstract.jdbc"
+     * }</pre>
+     *
+     * @param moduleName the name of the module
+     * @return the configuration property name for abstract features
+     */
+    public static String getAbstractFeaturePropertyName(String moduleName) {
+        return format(ABSTRACT_FEATURE_PROPERTY_NAME_PATTERN, moduleName);
+    }
+
+    /**
+     * Gets the configuration property name for a named feature of the specified module.
+     * <h3>Example Usage</h3>
+     * <pre>{@code
+     * // For module name "web" and feature name "rest-template"
+     * String propertyName = getNamedFeaturePropertyName("web", "rest-template");
+     * // Result: "microsphere.spring.cloud.features.named.web.rest-template"
+     * }</pre>
+     *
+     * @param moduleName  the name of the module
+     * @param featureName the name of the feature
+     * @return the configuration property name for the named feature
+     */
+    public static String getNamedFeaturePropertyName(String moduleName, String featureName) {
+        return format(NAMED_FEATURE_PROPERTY_NAME_PATTERN, moduleName, featureName);
+    }
+
+    /**
+     * Gets the bean name for {@link HasFeatures} of the specified module.
+     * <h3>Example Usage</h3>
+     * <pre>{@code
+     * // For module name "jdbc"
+     * String beanName = getHasFeaturesBeanName("jdbc");
+     * // Result: "jdbc.features"
+     * }</pre>
+     *
+     * @param moduleName the name of the module
+     * @return the bean name for {@link HasFeatures}
+     */
+    public static String getHasFeaturesBeanName(String moduleName) {
+        return moduleName + BEAN_NAME_SUFFIX;
+    }
+
+    /**
+     * Gets the qualified feature name for a named feature of the specified module.
+     * <h3>Example Usage</h3>
+     * <pre>{@code
+     * // For module name "web" and feature name "rest-template"
+     * String qualifiedName = getQualifierFeatureName("web", "rest-template");
+     * // Result: "microsphere.web.rest-template"
+     * }</pre>
+     *
+     * @param moduleName  the name of the module
+     * @param featureName the name of the feature
+     * @return the qualified feature name
+     */
+    public static String getQualifierFeatureName(String moduleName, String featureName) {
+        return MICROSPHERE_PROPERTY_NAME_PREFIX + moduleName + DOT_CHAR + featureName;
+    }
+
+    private FeaturesUtils() {
+    }
+}

--- a/microsphere-spring-cloud-commons/src/main/java/io/microsphere/spring/cloud/client/actuator/NamedFeatureComparator.java
+++ b/microsphere-spring-cloud-commons/src/main/java/io/microsphere/spring/cloud/client/actuator/NamedFeatureComparator.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.microsphere.spring.cloud.client.actuator;
+
+import org.springframework.cloud.client.actuator.NamedFeature;
+
+import java.util.Comparator;
+
+/**
+ * The {@link Comparator} class for {@link NamedFeature}
+ *
+ * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
+ * @see Comparator
+ * @see NamedFeature
+ * @since 1.0.0
+ */
+public class NamedFeatureComparator implements Comparator<NamedFeature> {
+
+    public static final NamedFeatureComparator INSTANCE = new NamedFeatureComparator();
+
+    @Override
+    public int compare(NamedFeature namedFeature1, NamedFeature namedFeature2) {
+        int c = namedFeature1.getName().compareTo(namedFeature2.getName());
+        if (c == 0) {
+            c = compare(namedFeature1.getType(), namedFeature2.getType());
+        }
+        return c;
+    }
+
+    private int compare(Class<?> type1, Class<?> type2) {
+        return type1.getName().compareTo(type2.getName());
+    }
+}

--- a/microsphere-spring-cloud-commons/src/main/java/io/microsphere/spring/cloud/client/actuator/constants/FeaturesConstants.java
+++ b/microsphere-spring-cloud-commons/src/main/java/io/microsphere/spring/cloud/client/actuator/constants/FeaturesConstants.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.microsphere.spring.cloud.client.actuator.constants;
+
+import org.springframework.cloud.client.actuator.HasFeatures;
+
+import static io.microsphere.constants.SymbolConstants.DOT;
+import static io.microsphere.spring.cloud.commons.constants.CommonsPropertyConstants.MICROSPHERE_SPRING_CLOUD_PROPERTY_NAME_PREFIX;
+
+/**
+ * The constants class for Spring Cloud {@link HasFeatures features}
+ *
+ * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
+ * @see HasFeatures
+ * @see org.springframework.cloud.client.actuator.FeaturesEndpoint
+ * @since 1.0.0
+ */
+public interface FeaturesConstants {
+
+    String FEATURES = "features";
+
+    String ABSTRACT = "abstract";
+
+    String NAMED = "named";
+
+    String PLACEHOLDER = "{}";
+
+    /**
+     * The prefix of the configuration properties for {@link HasFeatures} : "microsphere.spring.cloud.features"
+     */
+    String PROPERTY_NAME_PREFIX = MICROSPHERE_SPRING_CLOUD_PROPERTY_NAME_PREFIX + FEATURES;
+
+    /**
+     * The prefix of the configuration properties for abstract features: "microsphere.spring.cloud.features.abstract."
+     */
+    String ABSTRACT_FEATURE_PROPERTY_NAME_PREFIX = PROPERTY_NAME_PREFIX + DOT + ABSTRACT + DOT;
+
+    /**
+     * The prefix of the configuration properties for named features: "microsphere.spring.cloud.features.named."
+     */
+    String NAMED_FEATURE_PROPERTY_NAME_PREFIX = PROPERTY_NAME_PREFIX + DOT + NAMED + DOT;
+
+    /**
+     * The pattern of the configuration properties for abstract features: "microsphere.spring.cloud.features.abstract.{module-name}"
+     */
+    String ABSTRACT_FEATURE_PROPERTY_NAME_PATTERN = ABSTRACT_FEATURE_PROPERTY_NAME_PREFIX + PLACEHOLDER;
+
+    /**
+     * The pattern of the configuration properties for named features: "microsphere.spring.cloud.features.named.{module-name}.{feature-name}"
+     */
+    String NAMED_FEATURE_PROPERTY_NAME_PATTERN = NAMED_FEATURE_PROPERTY_NAME_PREFIX + PLACEHOLDER + DOT + PLACEHOLDER;
+
+    /**
+     * The suffix of the bean name for {@link HasFeatures} : ".features"
+     */
+    String BEAN_NAME_SUFFIX = DOT + FEATURES;
+}

--- a/microsphere-spring-cloud-commons/src/main/java/io/microsphere/spring/cloud/client/actuator/constants/FeaturesConstants.java
+++ b/microsphere-spring-cloud-commons/src/main/java/io/microsphere/spring/cloud/client/actuator/constants/FeaturesConstants.java
@@ -23,10 +23,10 @@ import static io.microsphere.constants.SymbolConstants.DOT;
 import static io.microsphere.spring.cloud.commons.constants.CommonsPropertyConstants.MICROSPHERE_SPRING_CLOUD_PROPERTY_NAME_PREFIX;
 
 /**
- * The constants class for Spring Cloud {@link HasFeatures features}
+ * The constants class for Spring Cloud {@link org.springframework.cloud.client.actuator.HasFeatures features}
  *
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
- * @see HasFeatures
+ * @see org.springframework.cloud.client.actuator.HasFeatures
  * @see org.springframework.cloud.client.actuator.FeaturesEndpoint
  * @since 1.0.0
  */

--- a/microsphere-spring-cloud-commons/src/main/java/io/microsphere/spring/cloud/client/service/registry/condition/ConditionalOnAutoServiceRegistrationAvailable.java
+++ b/microsphere-spring-cloud-commons/src/main/java/io/microsphere/spring/cloud/client/service/registry/condition/ConditionalOnAutoServiceRegistrationAvailable.java
@@ -20,13 +20,11 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.cloud.client.serviceregistry.AutoServiceRegistration;
 import org.springframework.cloud.client.serviceregistry.Registration;
-import org.springframework.core.annotation.AliasFor;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
-import static io.microsphere.spring.cloud.commons.constants.CommonsPropertyConstants.SERVICE_REGISTRY_AUTO_REGISTRATION_ENABLED_PROPERTY_NAME;
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;

--- a/microsphere-spring-cloud-commons/src/main/resources/META-INF/config/default/features.yaml
+++ b/microsphere-spring-cloud-commons/src/main/resources/META-INF/config/default/features.yaml
@@ -1,0 +1,121 @@
+microsphere:
+  spring:
+    cloud:
+      features:
+        abstract:
+          microsphere-spring-context:
+            - io.microsphere.spring.beans.factory.annotation.AnnotatedInjectionBeanPostProcessor
+            - io.microsphere.spring.beans.factory.config.GenericBeanPostProcessorAdapter
+            - io.microsphere.spring.context.event.GenericApplicationListenerAdapter
+            - io.microsphere.spring.context.event.OnceApplicationContextEventListener
+            - io.microsphere.spring.context.lifecycle.AbstractSmartLifecycle
+            ## ListenableAutowireCandidateResolverInitializer
+            - io.microsphere.spring.beans.factory.support.ListenableAutowireCandidateResolver
+            - io.microsphere.spring.beans.factory.support.AutowireCandidateResolvingListener
+            ## @EnableTTLCaching
+            - io.microsphere.spring.cache.intereptor.TTLCacheResolver
+            ## @Enable*
+            - io.microsphere.spring.context.annotation.BeanCapableImportCandidate
+            ## @OverrideAnnotationAttributes
+            - io.microsphere.spring.context.annotation.OverrideAnnotationAttributesStrategy
+            ## @EnableAutoRegistrationBean
+            - io.microsphere.spring.context.config.AutoRegistrationBean
+            ## @EnableConfigurationBeanBinding
+            - io.microsphere.spring.context.config.ConfigurationBeanBinder
+            - io.microsphere.spring.context.config.ConfigurationBeanCustomizer
+            - io.microsphere.spring.beans.factory.annotation.ConfigurationBeanBindingPostProcessor
+            ## @EnableEventExtension
+            - io.microsphere.spring.context.event.ApplicationEventInterceptor
+            - io.microsphere.spring.context.event.ApplicationListenerInterceptor
+            - io.microsphere.spring.context.event.InterceptingApplicationEventMulticaster
+            - io.microsphere.spring.context.event.InterceptingApplicationEventMulticasterProxy
+            ## EventPublishingBean*
+            - io.microsphere.spring.context.event.BeanFactoryListener
+            - io.microsphere.spring.context.event.BeanListener
+            - io.microsphere.spring.context.event.EventPublishingBeanBeforeProcessor
+            - io.microsphere.spring.context.event.EventPublishingBeanAfterProcessor
+            ## ListenableConfigurableEnvironment
+            - io.microsphere.spring.core.env.EnvironmentListener
+            - io.microsphere.spring.core.env.ProfileListener
+            - io.microsphere.spring.core.env.PropertyResolverListener
+            ## SpringProtocolURLStreamHandler
+            - io.microsphere.spring.net.SpringProtocolURLStreamHandler
+          microsphere-spring-guice:
+            ## @EnableGuice
+            - io.microsphere.spring.guice.annotation.GuiceInjectAnnotationBeanPostProcessor
+          microsphere-spring-jdbc:
+            ## @EnableP6DataSource
+            - io.microsphere.spring.jdbc.p6spy.beans.factory.config.P6DataSourceBeanPostProcessor
+          microsphere-spring-web:
+            ## @EnableWebExtension
+            - io.microsphere.spring.web.metadata.WebEndpointMappingResolver
+            - io.microsphere.spring.web.metadata.WebEndpointMappingRegistry
+            - io.microsphere.spring.web.metadata.WebEndpointMappingFactory
+            - io.microsphere.spring.web.metadata.WebEndpointMappingFilter
+            - io.microsphere.spring.web.metadata.WebEndpointMappingRegistrar
+            - io.microsphere.spring.web.method.support.HandlerMethodAdvice
+            - io.microsphere.spring.web.method.support.HandlerMethodArgumentInterceptor
+            - io.microsphere.spring.web.method.support.HandlerMethodInterceptor
+            - io.microsphere.spring.web.event.WebEventPublisher
+          microsphere-spring-webflux:
+            - io.microsphere.spring.webflux.server.filter.DelegatingWebFilter
+            - io.microsphere.spring.webflux.server.filter.RequestContextWebFilter
+            ## @EnableWebFluxExtension
+            - io.microsphere.spring.webflux.metadata.HandlerMappingWebEndpointMappingResolver
+            - io.microsphere.spring.webflux.method.InterceptingHandlerMethodProcessor
+            - io.microsphere.spring.webflux.server.filter.RequestHandledEventPublishingWebFilter
+            - io.microsphere.spring.webflux.server.filter.RequestContextWebFilter
+            - io.microsphere.spring.webflux.method.StoringRequestBodyArgumentInterceptor
+            - io.microsphere.spring.webflux.method.StoringResponseBodyReturnValueInterceptor
+            - io.microsphere.spring.webflux.handler.ReversedProxyHandlerMapping
+          microsphere-spring-webmvc:
+            - io.microsphere.spring.web.servlet.filter.ContentCachingFilter
+            ## @EnableWebMvcExtension
+            - io.microsphere.spring.webmvc.metadata.HandlerMappingWebEndpointMappingResolver
+            - io.microsphere.spring.webmvc.method.support.InterceptingHandlerMethodProcessor
+            - io.microsphere.spring.webmvc.interceptor.LazyCompositeHandlerInterceptor
+            - io.microsphere.spring.webmvc.advice.StoringRequestBodyArgumentAdvice
+            - io.microsphere.spring.webmvc.advice.StoringResponseBodyReturnValueAdvice
+            - io.microsphere.spring.webmvc.handler.ReversedProxyHandlerMapping
+            - io.microsphere.spring.web.metadata.ServletWebEndpointMappingResolver
+          microsphere-spring-boot:
+            - io.microsphere.spring.boot.context.config.BindableConfigurationBeanBinder
+            - io.microsphere.spring.boot.context.properties.bind.BindListener
+            - io.microsphere.spring.boot.context.properties.ListenableConfigurationPropertiesBindHandlerAdvisor
+            - io.microsphere.spring.boot.context.OnceApplicationPreparedEventListener
+            - io.microsphere.spring.boot.context.OnceMainApplicationPreparedEventListener
+
+        named:
+          microsphere-spring-context:
+            # InjectionPointDependencyResolver
+            ConstructionInjectionPointDependencyResolver: io.microsphere.spring.beans.factory.ConstructionInjectionPointDependencyResolver
+            AutowiredInjectionPointDependencyResolver: io.microsphere.spring.beans.factory.annotation.AutowiredInjectionPointDependencyResolver
+            ResourceInjectionPointDependencyResolver: io.microsphere.spring.beans.factory.annotation.ResourceInjectionPointDependencyResolver
+            # ApplicationContextInitializer
+            EventPublishingBeanInitializer: io.microsphere.spring.context.event.EventPublishingBeanInitializer
+            ListenableAutowireCandidateResolverInitializer: io.microsphere.spring.beans.factory.support.ListenableAutowireCandidateResolverInitializer
+            ListenableConfigurableEnvironmentInitializer: io.microsphere.spring.core.env.ListenableConfigurableEnvironmentInitializer
+            AutoRegistrationBeanInitializer: io.microsphere.spring.boot.context.config.AutoRegistrationBeanInitializer
+          microsphere-spring-webflux:
+            SpringWebFluxHelper: io.microsphere.spring.webflux.util.SpringWebFluxHelper
+          microsphere-spring-webmvc:
+            SpringWebMvcHelper: io.microsphere.spring.webmvc.util.SpringWebMvcHelper
+          microsphere-spring-boot:
+            # ApplicationContextInitializer
+            ConditionEvaluationReportInitializer: io.microsphere.spring.boot.report.ConditionEvaluationReportInitializer
+            OriginTrackedConfigurationPropertyInitializer: io.microsphere.spring.boot.env.config.OriginTrackedConfigurationPropertyInitializer
+            # SpringApplicationRunListener
+            BannedArtifactClassLoadingListener: io.microsphere.spring.boot.classloading.BannedArtifactClassLoadingListener
+            FailureReportSpringApplicationRunListener: io.microsphere.spring.boot.listener.FailureReportSpringApplicationRunListener
+            # ApplicationListener
+            ArtifactsCollisionDiagnosisListener: io.microsphere.spring.boot.diagnostics.ArtifactsCollisionDiagnosisListener
+            ConditionEvaluationReportListener: io.microsphere.spring.boot.report.ConditionEvaluationReportListener
+            DefaultPropertiesApplicationListener: io.microsphere.spring.boot.env.DefaultPropertiesApplicationListener
+            # SpringBootExceptionReporter
+            ConditionEvaluationSpringBootExceptionReporter: io.microsphere.spring.boot.report.ConditionEvaluationSpringBootExceptionReporter
+            # FailureAnalyzer
+            ArtifactsCollisionFailureAnalyzer: io.microsphere.spring.boot.diagnostics.ArtifactsCollisionFailureAnalyzer
+            # AutoConfigurationImportFilter
+            ConfigurableAutoConfigurationImportFilter: io.microsphere.spring.boot.autoconfigure.ConfigurableAutoConfigurationImportFilter
+            # DefaultPropertiesPostProcessor
+            SpringApplicationDefaultPropertiesPostProcessor: io.microsphere.spring.boot.env.SpringApplicationDefaultPropertiesPostProcessor

--- a/microsphere-spring-cloud-commons/src/main/resources/META-INF/config/default/features.yaml
+++ b/microsphere-spring-cloud-commons/src/main/resources/META-INF/config/default/features.yaml
@@ -84,6 +84,26 @@ microsphere:
             - io.microsphere.spring.boot.context.properties.ListenableConfigurationPropertiesBindHandlerAdvisor
             - io.microsphere.spring.boot.context.OnceApplicationPreparedEventListener
             - io.microsphere.spring.boot.context.OnceMainApplicationPreparedEventListener
+          microsphere-spring-cloud-commons:
+            ## Discovery Client
+            - io.microsphere.spring.cloud.client.discovery.UnionDiscoveryClient
+            - io.microsphere.spring.cloud.client.discovery.ReactiveDiscoveryClientAdapter
+            ## Service Registry
+            - io.microsphere.spring.cloud.client.service.registry.MultipleRegistration
+            - io.microsphere.spring.cloud.client.service.registry.MultipleServiceRegistry
+            - io.microsphere.spring.cloud.client.service.registry.MultipleAutoServiceRegistration
+            - io.microsphere.spring.cloud.client.service.registry.aspect.EventPublishingRegistrationAspect
+            - io.microsphere.spring.cloud.client.service.registry.SimpleServiceRegistry
+            - io.microsphere.spring.cloud.client.service.registry.SimpleAutoServiceRegistration
+            - io.microsphere.spring.cloud.client.service.registry.InMemoryServiceRegistry
+            ## Service Registry Actuator
+            - io.microsphere.spring.cloud.client.service.registry.endpoint.ServiceRegistrationEndpoint
+            - io.microsphere.spring.cloud.client.service.registry.endpoint.ServiceDeregistrationEndpoint
+            ## Spring Cloud Context
+            - io.microsphere.spring.cloud.context.named.config.SpecificationBeanPostProcessor
+            - io.microsphere.spring.cloud.context.named.SpecificationCustomizer
+            ## Tomcat
+            - io.microsphere.spring.cloud.fault.tolerance.tomcat.event.TomcatDynamicConfigurationListener
 
         named:
           microsphere-spring-context:

--- a/microsphere-spring-cloud-commons/src/test/java/io/microsphere/spring/cloud/client/actuator/ConfigurationPropertyHasFeaturesAutoConfigurationTest.java
+++ b/microsphere-spring-cloud-commons/src/test/java/io/microsphere/spring/cloud/client/actuator/ConfigurationPropertyHasFeaturesAutoConfigurationTest.java
@@ -81,7 +81,7 @@ class ConfigurationPropertyHasFeaturesAutoConfigurationTest {
         List<Class<?>> abstractFeatures = hasFeatures.getAbstractFeatures();
         List<NamedFeature> namedFeatures = hasFeatures.getNamedFeatures();
         assertEquals(1, namedFeatures.size());
-        assertEquals("microsphere.web.WebClient", namedFeatures.get(0).getName());
+        assertEquals("web:WebClient", namedFeatures.get(0).getName());
         assertTrue(abstractFeatures.isEmpty());
 
         hasFeatures = this.hasFeaturesBeansMap.get(getHasFeaturesBeanName("rest"));
@@ -89,7 +89,7 @@ class ConfigurationPropertyHasFeaturesAutoConfigurationTest {
 
         abstractFeatures = hasFeatures.getAbstractFeatures();
         namedFeatures = hasFeatures.getNamedFeatures();
-        assertEquals("microsphere.rest.RestTemplate", namedFeatures.get(0).getName());
+        assertEquals("rest:RestTemplate", namedFeatures.get(0).getName());
         assertEquals(1, namedFeatures.size());
         assertTrue(abstractFeatures.isEmpty());
 

--- a/microsphere-spring-cloud-commons/src/test/java/io/microsphere/spring/cloud/client/actuator/ConfigurationPropertyHasFeaturesAutoConfigurationTest.java
+++ b/microsphere-spring-cloud-commons/src/test/java/io/microsphere/spring/cloud/client/actuator/ConfigurationPropertyHasFeaturesAutoConfigurationTest.java
@@ -22,23 +22,18 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.client.actuator.FeaturesEndpoint;
 import org.springframework.cloud.client.actuator.HasFeatures;
 import org.springframework.cloud.client.actuator.NamedFeature;
-import org.springframework.web.client.RestOperations;
 import org.springframework.web.client.RestTemplate;
 
 import java.util.List;
 import java.util.Map;
 
-import static io.microsphere.spring.cloud.client.actuator.ConfigurationPropertyHasFeaturesAutoConfiguration.ABSTRACT_FEATURE_PROPERTY_NAME_PATTERN;
-import static io.microsphere.spring.cloud.client.actuator.ConfigurationPropertyHasFeaturesAutoConfiguration.BEAN_NAME_SUFFIX;
-import static io.microsphere.spring.cloud.client.actuator.ConfigurationPropertyHasFeaturesAutoConfiguration.NAME;
-import static io.microsphere.spring.cloud.client.actuator.ConfigurationPropertyHasFeaturesAutoConfiguration.NAMED_FEATURE_PROPERTY_NAME_PATTERN;
-import static io.microsphere.spring.cloud.client.actuator.ConfigurationPropertyHasFeaturesAutoConfiguration.PROPERTY_PREFIX;
-import static io.microsphere.spring.cloud.client.actuator.ConfigurationPropertyHasFeaturesAutoConfiguration.getBeanName;
-import static io.microsphere.spring.cloud.client.actuator.ConfigurationPropertyHasFeaturesAutoConfiguration.getQualifierFeatureName;
+import static io.microsphere.spring.cloud.client.actuator.FeaturesUtils.getHasFeaturesBeanName;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -49,15 +44,19 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * @since 1.0.0
  */
 @SpringBootTest(
-        classes = ConfigurationPropertyHasFeaturesAutoConfigurationTest.class,
+        classes = {
+                RestTemplate.class,
+                ConfigurationPropertyHasFeaturesAutoConfigurationTest.class
+        },
         properties = {
-                "microsphere.spring.cloud.features.jdbc.JdbcTemplate=org.springframework.jdbc.core.JdbcTemplate",
-                "microsphere.spring.cloud.features.rest.RestTemplate=org.springframework.web.client.RestTemplate",
-                "microsphere.spring.cloud.features.rest=org.springframework.web.client.RestOperations",
-                "microsphere.spring.cloud.features.redis.RedisConnection=org.springframework.data.redis.connection.RedisConnection",
-                "microsphere.spring.cloud.features.redis=org.springframework.data.redis.connection.RedisConnectionFactory," +
+                "microsphere.spring.cloud.features.abstract.rest=org.springframework.web.client.RestOperations",
+                "microsphere.spring.cloud.features.abstract.redis=org.springframework.data.redis.connection.RedisConnectionFactory," +
                         "org.springframework.data.redis.core.RedisTemplate," +
                         "org.springframework.data.redis.core.StringRedisTemplate",
+                "microsphere.spring.cloud.features.named.jdbc.JdbcTemplate=org.springframework.jdbc.core.JdbcTemplate",
+                "microsphere.spring.cloud.features.named.rest.RestTemplate=org.springframework.web.client.RestTemplate",
+                "microsphere.spring.cloud.features.named.redis.RedisConnection=org.springframework.data.redis.connection.RedisConnection",
+                "microsphere.spring.cloud.features.named.web.WebClient=org.springframework.web.reactive.function.client.WebClient"
         }
 )
 @EnableAutoConfiguration
@@ -66,42 +65,35 @@ class ConfigurationPropertyHasFeaturesAutoConfigurationTest {
     @Autowired
     private Map<String, HasFeatures> hasFeaturesBeansMap;
 
+    @Autowired
+    private FeaturesEndpoint featuresEndpoint;
+
     @Test
     void test() {
+        HasFeatures hasFeatures = this.hasFeaturesBeansMap.get(getHasFeaturesBeanName("jdbc"));
+        assertNull(hasFeatures);
 
-        testConstants();
+        hasFeatures = this.hasFeaturesBeansMap.get(getHasFeaturesBeanName("redis"));
+        assertNull(hasFeatures);
 
-        HasFeatures hasFeatures = this.hasFeaturesBeansMap.get(getBeanName("jdbc"));
+        hasFeatures = this.hasFeaturesBeansMap.get(getHasFeaturesBeanName("web"));
         assertNotNull(hasFeatures);
-        assertTrue(hasFeatures.getAbstractFeatures().isEmpty());
-        assertTrue(hasFeatures.getNamedFeatures().isEmpty());
-
-        hasFeatures = this.hasFeaturesBeansMap.get(getBeanName("rest"));
-        assertNotNull(hasFeatures);
-
         List<Class<?>> abstractFeatures = hasFeatures.getAbstractFeatures();
-        assertEquals(1, abstractFeatures.size());
-        assertEquals(RestOperations.class, abstractFeatures.get(0));
-
         List<NamedFeature> namedFeatures = hasFeatures.getNamedFeatures();
         assertEquals(1, namedFeatures.size());
-        NamedFeature namedFeature = namedFeatures.get(0);
-        assertEquals(getQualifierFeatureName("rest", "RestTemplate"), namedFeature.getName());
-        assertEquals(RestTemplate.class, namedFeature.getType());
+        assertEquals("microsphere.web.WebClient", namedFeatures.get(0).getName());
+        assertTrue(abstractFeatures.isEmpty());
 
-        hasFeatures = this.hasFeaturesBeansMap.get(getBeanName("redis"));
+        hasFeatures = this.hasFeaturesBeansMap.get(getHasFeaturesBeanName("rest"));
         assertNotNull(hasFeatures);
-        assertTrue(hasFeatures.getAbstractFeatures().isEmpty());
-        assertTrue(hasFeatures.getNamedFeatures().isEmpty());
 
+        abstractFeatures = hasFeatures.getAbstractFeatures();
+        namedFeatures = hasFeatures.getNamedFeatures();
+        assertEquals("microsphere.rest.RestTemplate", namedFeatures.get(0).getName());
+        assertEquals(1, namedFeatures.size());
+        assertTrue(abstractFeatures.isEmpty());
+
+
+        assertNotNull(featuresEndpoint.features());
     }
-
-    private void testConstants() {
-        assertEquals("features", NAME);
-        assertEquals("microsphere.spring.cloud.features.", PROPERTY_PREFIX);
-        assertEquals("microsphere.spring.cloud.features.{}", ABSTRACT_FEATURE_PROPERTY_NAME_PATTERN);
-        assertEquals("microsphere.spring.cloud.features.{}.{}", NAMED_FEATURE_PROPERTY_NAME_PATTERN);
-        assertEquals(".features", BEAN_NAME_SUFFIX);
-    }
-
 }

--- a/microsphere-spring-cloud-commons/src/test/java/io/microsphere/spring/cloud/client/actuator/FeaturesUtilsTest.java
+++ b/microsphere-spring-cloud-commons/src/test/java/io/microsphere/spring/cloud/client/actuator/FeaturesUtilsTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.microsphere.spring.cloud.client.actuator;
+
+
+import org.junit.jupiter.api.Test;
+
+import static io.microsphere.spring.cloud.client.actuator.FeaturesUtils.getAbstractFeaturePropertyName;
+import static io.microsphere.spring.cloud.client.actuator.FeaturesUtils.getHasFeaturesBeanName;
+import static io.microsphere.spring.cloud.client.actuator.FeaturesUtils.getNamedFeaturePropertyName;
+import static io.microsphere.spring.cloud.client.actuator.FeaturesUtils.getQualifierFeatureName;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * {@link FeaturesUtils} Test
+ *
+ * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
+ * @see FeaturesUtils
+ * @since 1.0.0
+ */
+class FeaturesUtilsTest {
+
+    @Test
+    void testGetAbstractFeaturePropertyName() {
+        String propertyName = getAbstractFeaturePropertyName("jdbc");
+        assertEquals("microsphere.spring.cloud.features.abstract.jdbc", propertyName);
+    }
+
+    @Test
+    void testGetNamedFeaturePropertyName() {
+        String propertyName = getNamedFeaturePropertyName("jdbc", "JdbcTemplate");
+        assertEquals("microsphere.spring.cloud.features.named.jdbc.JdbcTemplate", propertyName);
+    }
+
+    @Test
+    void testGetHasFeaturesBeanName() {
+        String beanName = getHasFeaturesBeanName("jdbc");
+        assertEquals("jdbc.features", beanName);
+    }
+
+    @Test
+    void testGetQualifierFeatureName() {
+        String featureName = getQualifierFeatureName("web", "rest-template");
+        assertEquals("microsphere.web.rest-template", featureName);
+    }
+}

--- a/microsphere-spring-cloud-commons/src/test/java/io/microsphere/spring/cloud/client/actuator/FeaturesUtilsTest.java
+++ b/microsphere-spring-cloud-commons/src/test/java/io/microsphere/spring/cloud/client/actuator/FeaturesUtilsTest.java
@@ -56,6 +56,6 @@ class FeaturesUtilsTest {
     @Test
     void testGetQualifierFeatureName() {
         String featureName = getQualifierFeatureName("web", "rest-template");
-        assertEquals("microsphere.web.rest-template", featureName);
+        assertEquals("web:rest-template", featureName);
     }
 }

--- a/microsphere-spring-cloud-commons/src/test/java/io/microsphere/spring/cloud/client/actuator/constants/FeaturesConstantsTest.java
+++ b/microsphere-spring-cloud-commons/src/test/java/io/microsphere/spring/cloud/client/actuator/constants/FeaturesConstantsTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.microsphere.spring.cloud.client.actuator.constants;
+
+
+import org.junit.jupiter.api.Test;
+
+import static io.microsphere.spring.cloud.client.actuator.constants.FeaturesConstants.ABSTRACT;
+import static io.microsphere.spring.cloud.client.actuator.constants.FeaturesConstants.ABSTRACT_FEATURE_PROPERTY_NAME_PATTERN;
+import static io.microsphere.spring.cloud.client.actuator.constants.FeaturesConstants.ABSTRACT_FEATURE_PROPERTY_NAME_PREFIX;
+import static io.microsphere.spring.cloud.client.actuator.constants.FeaturesConstants.BEAN_NAME_SUFFIX;
+import static io.microsphere.spring.cloud.client.actuator.constants.FeaturesConstants.FEATURES;
+import static io.microsphere.spring.cloud.client.actuator.constants.FeaturesConstants.NAMED;
+import static io.microsphere.spring.cloud.client.actuator.constants.FeaturesConstants.NAMED_FEATURE_PROPERTY_NAME_PATTERN;
+import static io.microsphere.spring.cloud.client.actuator.constants.FeaturesConstants.NAMED_FEATURE_PROPERTY_NAME_PREFIX;
+import static io.microsphere.spring.cloud.client.actuator.constants.FeaturesConstants.PLACEHOLDER;
+import static io.microsphere.spring.cloud.client.actuator.constants.FeaturesConstants.PROPERTY_NAME_PREFIX;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * {@link FeaturesConstants} Test
+ *
+ * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
+ * @see FeaturesConstants
+ * @since 1.0.0
+ */
+class FeaturesConstantsTest {
+
+    @Test
+    void testConstants() {
+        assertEquals("features", FEATURES);
+        assertEquals("abstract", ABSTRACT);
+        assertEquals("named", NAMED);
+        assertEquals("{}", PLACEHOLDER);
+
+        assertEquals("microsphere.spring.cloud.features", PROPERTY_NAME_PREFIX);
+        assertEquals("microsphere.spring.cloud.features.abstract.", ABSTRACT_FEATURE_PROPERTY_NAME_PREFIX);
+        assertEquals("microsphere.spring.cloud.features.named.", NAMED_FEATURE_PROPERTY_NAME_PREFIX);
+        assertEquals("microsphere.spring.cloud.features.abstract.{}", ABSTRACT_FEATURE_PROPERTY_NAME_PATTERN);
+        assertEquals("microsphere.spring.cloud.features.named.{}.{}", NAMED_FEATURE_PROPERTY_NAME_PATTERN);
+        assertEquals(".features", BEAN_NAME_SUFFIX);
+    }
+}

--- a/microsphere-spring-cloud-parent/pom.xml
+++ b/microsphere-spring-cloud-parent/pom.xml
@@ -20,7 +20,7 @@
 
     <properties>
         <!-- BOM versions -->
-        <microsphere-spring-boot.version>0.1.22</microsphere-spring-boot.version>
+        <microsphere-spring-boot.version>0.1.23</microsphere-spring-boot.version>
         <testcontainers.version>1.21.4</testcontainers.version>
         <!-- Testing -->
         <junit-jupiter.version>5.14.4</junit-jupiter.version>

--- a/microsphere-spring-cloud-parent/pom.xml
+++ b/microsphere-spring-cloud-parent/pom.xml
@@ -20,7 +20,7 @@
 
     <properties>
         <!-- BOM versions -->
-        <microsphere-spring-boot.version>0.1.26</microsphere-spring-boot.version>
+        <microsphere-spring-boot.version>0.1.27</microsphere-spring-boot.version>
         <testcontainers.version>1.21.4</testcontainers.version>
         <!-- Testing -->
         <junit-jupiter.version>5.14.4</junit-jupiter.version>

--- a/microsphere-spring-cloud-parent/pom.xml
+++ b/microsphere-spring-cloud-parent/pom.xml
@@ -20,7 +20,7 @@
 
     <properties>
         <!-- BOM versions -->
-        <microsphere-spring-boot.version>0.1.24</microsphere-spring-boot.version>
+        <microsphere-spring-boot.version>0.1.25</microsphere-spring-boot.version>
         <testcontainers.version>1.21.4</testcontainers.version>
         <!-- Testing -->
         <junit-jupiter.version>5.14.4</junit-jupiter.version>

--- a/microsphere-spring-cloud-parent/pom.xml
+++ b/microsphere-spring-cloud-parent/pom.xml
@@ -20,7 +20,7 @@
 
     <properties>
         <!-- BOM versions -->
-        <microsphere-spring-boot.version>0.1.25</microsphere-spring-boot.version>
+        <microsphere-spring-boot.version>0.1.26</microsphere-spring-boot.version>
         <testcontainers.version>1.21.4</testcontainers.version>
         <!-- Testing -->
         <junit-jupiter.version>5.14.4</junit-jupiter.version>

--- a/microsphere-spring-cloud-parent/pom.xml
+++ b/microsphere-spring-cloud-parent/pom.xml
@@ -20,7 +20,7 @@
 
     <properties>
         <!-- BOM versions -->
-        <microsphere-spring-boot.version>0.1.23</microsphere-spring-boot.version>
+        <microsphere-spring-boot.version>0.1.24</microsphere-spring-boot.version>
         <testcontainers.version>1.21.4</testcontainers.version>
         <!-- Testing -->
         <junit-jupiter.version>5.14.4</junit-jupiter.version>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.github.microsphere-projects</groupId>
         <artifactId>microsphere-build</artifactId>
-        <version>0.3.4</version>
+        <version>0.3.5</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
This pull request refactors and improves the way Spring Cloud Client Actuator features are registered and configured via properties. The main changes include introducing a new strongly-typed configuration properties class, extracting utility methods, and updating the property structure for clarity and maintainability.

**Key improvements:**
- The configuration property structure for registering features is now more explicit and type-safe, using a dedicated `FeaturesProperties` class.
- Utility methods for feature property and bean name generation have been moved to a new `FeaturesUtils` class.
- The property format for abstract and named features is changed for better clarity.
- The code for registering features has been simplified and made more robust.

### Configuration property and structure improvements
* Introduced a new `FeaturesProperties` class annotated with `@ConfigurationProperties`, providing explicit, type-safe access to `abstract` and `named` feature definitions in configuration files. This replaces manual parsing of environment properties and supports better validation and IDE support.
* Changed the property format for defining features: abstract features now use the prefix `microsphere.spring.cloud.features.abstract.<module>`, and named features use `microsphere.spring.cloud.features.named.<module>.<feature>`, replacing the previous flat structure.

### Codebase simplification and maintainability
* Extracted all utility methods for property name and bean name generation (such as `getAbstractFeaturePropertyName`, `getNamedFeaturePropertyName`, etc.) into a new `FeaturesUtils` utility class, improving code reuse and clarity.
* Refactored `ConfigurationPropertyHasFeaturesAutoConfiguration` to use the new `FeaturesProperties` class and utility methods, removed legacy property parsing logic, and improved feature registration logic for better maintainability and correctness. [[1]](diffhunk://#diff-fbab87d6a7c4b108e7c5c7af957a9cfc1b863d42e8dbcf272d8c857ef66668dcR21-R61) [[2]](diffhunk://#diff-fbab87d6a7c4b108e7c5c7af957a9cfc1b863d42e8dbcf272d8c857ef66668dcL90-R103) [[3]](diffhunk://#diff-fbab87d6a7c4b108e7c5c7af957a9cfc1b863d42e8dbcf272d8c857ef66668dcL130-R235)

### Internal data structure improvements
* Changed the internal collections for holding features from `List` to `Set` (specifically, `LinkedHashSet` and `TreeSet`) to avoid duplicates and ensure predictable ordering when registering features.