### PR TITLE
Update README branch version table

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,8 @@ Then declare only the modules you need (versions are managed by the BOM):
 
 | **Branch** | **Spring Cloud compatibility**         | **Latest version** |
 |------------|----------------------------------------|--------------------|
-| `main`     | 2022.0.x, 2023.0.x, 2024.0.x, 2025.0.x | `0.2.19`           |
-| `1.x`      | Hoxton, 2020.0.x, 2021.0.x             | `0.1.19`           |
+| `main`     | 2022.0.x, 2023.0.x, 2024.0.x, 2025.0.x | `0.2.20`           |
+| `1.x`      | Hoxton, 2020.0.x, 2021.0.x             | `0.1.20`           |
 
 By default, the `main` branch builds against Spring Cloud 2025.0.x. To build or run tests against an older generation,
 activate the corresponding Maven profile:


### PR DESCRIPTION
Refresh the compatibility table in README.md to reflect the latest released versions: `main` from `0.2.19` to `0.2.20` and `1.x` from `0.1.19` to `0.1.20`.