### PR TITLE
Bump microsphere-spring-boot to 0.1.28 and update README versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,8 @@ Then declare only the modules you need (versions are managed by the BOM):
 
 | **Branch** | **Spring Cloud compatibility**         | **Latest version** |
 |------------|----------------------------------------|--------------------|
-| `main`     | 2022.0.x, 2023.0.x, 2024.0.x, 2025.0.x | `0.2.20`           |
-| `1.x`      | Hoxton, 2020.0.x, 2021.0.x             | `0.1.20`           |
+| `main`     | 2022.0.x, 2023.0.x, 2024.0.x, 2025.0.x | `0.2.21`           |
+| `1.x`      | Hoxton, 2020.0.x, 2021.0.x             | `0.1.21`           |
 
 By default, the `main` branch builds against Spring Cloud 2025.0.x. To build or run tests against an older generation,
 activate the corresponding Maven profile:

--- a/microsphere-spring-cloud-openfeign/src/main/resources/META-INF/config/default/features.yaml
+++ b/microsphere-spring-cloud-openfeign/src/main/resources/META-INF/config/default/features.yaml
@@ -1,0 +1,18 @@
+microsphere:
+  spring:
+    cloud:
+      features:
+        abstract:
+          spring-cloud-openfeign-core:
+            - feign.Client
+            - feign.Capability
+            - org.springframework.cloud.openfeign.Targeter
+            - org.springframework.cloud.openfeign.FeignClientFactory
+            - org.springframework.cloud.openfeign.FeignClientsConfiguration
+            - org.springframework.cloud.openfeign.FeignClientSpecification
+            - org.springframework.cloud.openfeign.FallbackFactory
+            - org.springframework.cloud.openfeign.CircuitBreakerNameResolver
+            - org.springframework.cloud.openfeign.FeignBuilderCustomizer
+          microsphere-spring-cloud-openfeign:
+            - io.microsphere.spring.cloud.openfeign.autorefresh.FeignComponentRegistry
+            - io.microsphere.spring.cloud.openfeign.autorefresh.AutoRefreshCapability

--- a/microsphere-spring-cloud-parent/pom.xml
+++ b/microsphere-spring-cloud-parent/pom.xml
@@ -20,7 +20,7 @@
 
     <properties>
         <!-- BOM versions -->
-        <microsphere-spring-boot.version>0.1.27</microsphere-spring-boot.version>
+        <microsphere-spring-boot.version>0.1.28</microsphere-spring-boot.version>
         <testcontainers.version>1.21.4</testcontainers.version>
         <!-- Testing -->
         <junit-jupiter.version>5.14.4</junit-jupiter.version>


### PR DESCRIPTION
This pull request updates version numbers for both the project and its dependencies to ensure compatibility and access to the latest features and fixes.

Dependency updates:

* Updated the `microsphere-spring-boot.version` property from `0.1.27` to `0.1.28` in `microsphere-spring-cloud-parent/pom.xml`.

Documentation updates:

* Updated the latest release versions in the compatibility table in `README.md` (`main`: `0.2.21`, `1.x`: `0.1.21`).