### PR TITLE
Polish Javadocs, reorganize POM dependencies, and update versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Then declare only the modules you need (versions are managed by the BOM):
 | **Branch** | **Spring Cloud compatibility**         | **Latest version** |
 |------------|----------------------------------------|--------------------|
 | `main`     | 2022.0.x, 2023.0.x, 2024.0.x, 2025.0.x | `0.2.24`           |
-| `1.x`      | Hoxton, 2020.0.x, 2021.0.x             | `0.1.24`            |
+| `1.x`      | Hoxton, 2020.0.x, 2021.0.x             | `0.1.24`           |
 
 By default, the `main` branch builds against Spring Cloud 2025.0.x. To build or run tests against an older generation,
 activate the corresponding Maven profile:

--- a/README.md
+++ b/README.md
@@ -114,8 +114,8 @@ Then declare only the modules you need (versions are managed by the BOM):
 
 | **Branch** | **Spring Cloud compatibility**         | **Latest version** |
 |------------|----------------------------------------|--------------------|
-| `main`     | 2022.0.x, 2023.0.x, 2024.0.x, 2025.0.x | `0.2.23`           |
-| `1.x`      | Hoxton, 2020.0.x, 2021.0.x             | `0.1.23`           |
+| `main`     | 2022.0.x, 2023.0.x, 2024.0.x, 2025.0.x | `0.2.24`           |
+| `1.x`      | Hoxton, 2020.0.x, 2021.0.x             | `0.1.24`            |
 
 By default, the `main` branch builds against Spring Cloud 2025.0.x. To build or run tests against an older generation,
 activate the corresponding Maven profile:

--- a/microsphere-spring-cloud-commons/pom.xml
+++ b/microsphere-spring-cloud-commons/pom.xml
@@ -48,43 +48,6 @@
             <artifactId>microsphere-spring-boot-actuator</artifactId>
         </dependency>
 
-        <!-- Spring Boot Dependencies -->
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter</artifactId>
-            <optional>true</optional>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
-            <optional>true</optional>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-webflux</artifactId>
-            <optional>true</optional>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-configuration-processor</artifactId>
-            <optional>true</optional>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-autoconfigure-processor</artifactId>
-            <optional>true</optional>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-actuator</artifactId>
-            <optional>true</optional>
-        </dependency>
-
         <!-- Spring Cloud Dependencies -->
         <dependency>
             <groupId>org.springframework.cloud</groupId>
@@ -138,6 +101,44 @@
             <optional>true</optional>
         </dependency>
 
+        <!-- Spring Boot Dependencies -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webflux</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- AspectJ -->
         <dependency>
             <groupId>org.aspectj</groupId>
             <artifactId>aspectjweaver</artifactId>

--- a/microsphere-spring-cloud-commons/src/main/java/io/microsphere/spring/cloud/client/discovery/condition/ConditionalOnBlockingDiscoveryAvailable.java
+++ b/microsphere-spring-cloud-commons/src/main/java/io/microsphere/spring/cloud/client/discovery/condition/ConditionalOnBlockingDiscoveryAvailable.java
@@ -38,7 +38,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * {@link ConditionalOnDiscoveryEnabled}, and {@link ConditionalOnBlockingDiscoveryEnabled} to ensure that
  * the discovery client is both present in the classpath and enabled for blocking operations.
  *
- * <h3>Example Usage:</h3>
+ * <h3>Example Usage</h3>
  * <pre>{@code
  * @Configuration
  * @ConditionalOnDiscoveryAvailable

--- a/microsphere-spring-cloud-commons/src/main/java/io/microsphere/spring/cloud/client/discovery/condition/ConditionalOnReactiveDiscoveryAvailable.java
+++ b/microsphere-spring-cloud-commons/src/main/java/io/microsphere/spring/cloud/client/discovery/condition/ConditionalOnReactiveDiscoveryAvailable.java
@@ -41,7 +41,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *     <li>The Reactive Discovery Client class is present on the classpath.</li>
  * </ul>
  *
- * <h3>Example Usage:</h3>
+ * <h3>Example Usage</h3>
  * <pre>{@code
  * @Configuration
  * public class ReactiveDiscoveryConfig {

--- a/microsphere-spring-cloud-openfeign/pom.xml
+++ b/microsphere-spring-cloud-openfeign/pom.xml
@@ -27,19 +27,6 @@
             <optional>true</optional>
         </dependency>
 
-        <!-- Spring Boot Dependencies -->
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-configuration-processor</artifactId>
-            <optional>true</optional>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-autoconfigure-processor</artifactId>
-            <optional>true</optional>
-        </dependency>
-
         <!-- Microsphere Spring Cloud Commons -->
         <dependency>
             <groupId>io.github.microsphere-projects</groupId>
@@ -69,13 +56,13 @@
         <!-- Spring Boot Dependencies -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter</artifactId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
             <optional>true</optional>
         </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
+            <artifactId>spring-boot-autoconfigure-processor</artifactId>
             <optional>true</optional>
         </dependency>
 

--- a/microsphere-spring-cloud-parent/pom.xml
+++ b/microsphere-spring-cloud-parent/pom.xml
@@ -20,7 +20,7 @@
 
     <properties>
         <!-- BOM versions -->
-        <microsphere-spring-boot.version>0.1.31</microsphere-spring-boot.version>
+        <microsphere-spring-boot.version>0.1.32</microsphere-spring-boot.version>
         <testcontainers.version>1.21.4</testcontainers.version>
         <!-- Testing -->
         <junit-jupiter.version>5.14.4</junit-jupiter.version>


### PR DESCRIPTION
This pull request updates versions and refines dependencies for better alignment with Spring Cloud and Spring Boot practices. The most significant changes include updating the project version, reorganizing dependencies in `microsphere-spring-cloud-commons` to group them by their function, and cleaning up unnecessary or misplaced dependencies in related modules.

**Version updates:**

* Updated documentation and BOM to reference the latest versions: `0.2.24` for `main`, `0.1.24` for `1.x`, and `microsphere-spring-boot.version` to `0.1.32`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L117-R118) [[2]](diffhunk://#diff-fa345c4629e597e0d079119721098966f58cd57b6eb4223ae89dd8d4c3e9bb96L23-R23)

**Dependency management improvements:**

* Reorganized and clarified dependencies in `microsphere-spring-cloud-commons/pom.xml`, grouping them by their role (Spring Cloud, Netflix Eureka, Alibaba Nacos, Zookeeper, Consul, Spring Boot, AspectJ), and ensuring optional dependencies are appropriately marked.
* Cleaned up `microsphere-spring-cloud-openfeign/pom.xml` by removing unnecessary Spring Boot processor dependencies from the main dependency list and moving them to the appropriate section. [[1]](diffhunk://#diff-496eb0cd75922108b85efbad15a27e28b16febb166c9f562990da54487e53364L30-L42) [[2]](diffhunk://#diff-496eb0cd75922108b85efbad15a27e28b16febb166c9f562990da54487e53364L72-R65)

**Documentation and code style:**

* Minor documentation improvements: removed the colon from `<h3>Example Usage:</h3>` headings in JavaDoc for consistency. [[1]](diffhunk://#diff-9c7c548697997e3998107c73ce8d6011069684f5f2a4af24edff86d3ff701653L41-R41) [[2]](diffhunk://#diff-f6b9cb31d1b04547a1cb9bd352aee564de781532b5bc9bf9e4b3bb48e88ecc2fL44-R44)